### PR TITLE
Don't track deferred fields

### DIFF
--- a/src/dirtyfields/compat.py
+++ b/src/dirtyfields/compat.py
@@ -1,5 +1,6 @@
 import django
 from django.db.models import signals
+from django.db.models.query_utils import DeferredAttribute
 
 
 def is_db_expression(value):
@@ -11,6 +12,11 @@ def is_db_expression(value):
         # django >= 1.8  (big refactoring in Lookup/Expressions/Transforms)
         from django.db.models.expressions import BaseExpression, Combinable
         return isinstance(value, (BaseExpression, Combinable))
+
+
+def is_deferred(model, field):
+    attr = model.__class__.__dict__.get(field.attname)
+    return isinstance(attr, DeferredAttribute)
 
 
 def save_specific_fields(instance, fields_list):

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -2,7 +2,7 @@
 from copy import copy
 
 from django.db.models.signals import post_save
-from .compat import is_db_expression, save_specific_fields
+from .compat import is_db_expression, save_specific_fields, is_deferred
 
 
 class DirtyFieldsMixin(object):
@@ -21,6 +21,9 @@ class DirtyFieldsMixin(object):
             if field.rel:
                 if not check_relationship:
                     continue
+
+            if is_deferred(self, field):
+                continue
 
             field_value = getattr(self, field.attname)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -101,3 +101,18 @@ def test_decimal_field_correctly_managed():
 
     tm.decimal_field = u"2.00"
     assert not tm.is_dirty()
+
+
+@pytest.mark.django_db
+def test_deferred_fields():
+    TestModel.objects.create()
+
+    qs = TestModel.objects.only('boolean')
+
+    tm = qs[0]
+    tm.boolean = False
+    assert tm.get_dirty_fields() == {'boolean': True}
+
+    tm.characters = 'foo'
+    # 'characters' is not tracked as it is deferred
+    assert tm.get_dirty_fields() == {'boolean': True}


### PR DESCRIPTION
If a field is deferred, `DirtyFieldsMixin` will try to access it value, causing an infinite recursion.

This PR exclude deferred fields from dirtyfields's mechanism.

If you want to test the current behavior, you can launch the test with django-dirtyfields 0.8 and you will the infinite recursion.