### PR TITLE
Fix validationerror

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -1,6 +1,7 @@
 # Adapted from http://stackoverflow.com/questions/110803/dirty-fields-in-django
 from copy import copy
 
+from django.core.exceptions import ValidationError
 from django.db.models.signals import post_save
 from .compat import is_db_expression, save_specific_fields, is_deferred
 
@@ -31,9 +32,16 @@ class DirtyFieldsMixin(object):
             if is_db_expression(field_value):
                 continue
 
+            try:
+                # Store the converted value for fields with conversion
+                field_value = field.to_python(field_value)
+            except ValidationError:
+                # The current value is not valid so we cannot convert it
+                pass
+
             # Explanation of copy usage here :
             # https://github.com/smn/django-dirtyfields/commit/efd0286db8b874b5d6bd06c9e903b1a0c9cc6b00
-            all_field[field.name] = copy(field.to_python(field_value))
+            all_field[field.name] = copy(field_value)
 
         return all_field
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -116,3 +116,14 @@ def test_deferred_fields():
     tm.characters = 'foo'
     # 'characters' is not tracked as it is deferred
     assert tm.get_dirty_fields() == {'boolean': True}
+
+
+def test_validationerror():
+    # Initialize the model with an invalid value
+    tm = TestModel(boolean=None)
+
+    # Should not raise ValidationError
+    assert tm.is_dirty() is True
+
+    tm.boolean = False
+    assert tm.get_dirty_fields() == {'boolean': None}


### PR DESCRIPTION
When a model in instantiated with an invalid value for a field, a ValidationError is raised when calling `.get_dirty_fields()`.
This is due to the call of `field.to_python(value)`, which can raise this error (cf [`BooleanField.to_python`](https://github.com/django/django/blob/976bd519a879b2fd7a356cb21bde32696adb545f/django/db/models/fields/__init__.py#L1035-L1039) for example).

This PR fixes the issue by storing the current value instead of the converted one if the conversion failed.