### PR TITLE
Regression test for recursion error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ ve
 docs/_build/*
 docs/_template/*
 docs/_static/*
+.tox
+.cache
+.coverage

--- a/tests/test_non_regression.py
+++ b/tests/test_non_regression.py
@@ -10,6 +10,16 @@ from .utils import assert_select_number_queries_on_model
 
 
 @pytest.mark.django_db
+def test_slicing_and_only():
+    # test for bug: https://github.com/depop/django-dirtyfields/issues/1
+    for _ in range(10):
+        TestModelWithNonEditableFields.objects.create()
+
+    qs_ = TestModelWithNonEditableFields.objects.only('pk').filter()
+    [o for o in qs_.filter().order_by('pk')]
+
+
+@pytest.mark.django_db
 def test_dirty_fields_ignores_the_editable_property_of_fields():
     # Non regression test case for bug:
     # https://github.com/romgar/django-dirtyfields/issues/17

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = django14,django15,django16,django17,django18,coverage
 
 [testenv]
-commands = py.test
+commands = py.test -v
 deps =
     pytest
     pytest-django


### PR DESCRIPTION
We had been using a fork from 0.7.0 version because we'd encountered a situation that resulted in recursion error from dirtyfields

I wanted to see if we could get back to using your upstream version with the latest fixes, this test confirms that the error no longer occurs.