### PR TITLE
Adding verbose option for more explicit output on get_dirty_fields

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Tracking dirty fields on a Django model instance.
 
 Dirty means that there is a difference between field value in the database and the one we currently have on a model instance.
 
-`Documentation <http://django-dirtyfields.readthedocs.org/en/develop/>`_
+`Full documentation <http://django-dirtyfields.readthedocs.org/en/develop/>`_
 
 Install
 =======
@@ -69,7 +69,7 @@ Example
     {'boolean': True}
 
 
-Consult the `Documentation <http://django-dirtyfields.readthedocs.org/en/develop/>`_ for more informations.
+Consult the `full documentation <http://django-dirtyfields.readthedocs.org/en/develop/>`_ for more informations.
 
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -102,8 +102,8 @@ But, in django 1.4.22-, as we are using under the hood an ``update`` method, we 
 
 Verbose mode
 ----------------------------
-By default, when you use ``get_dirty_fields` function, if there are dirty fields, only the old value is returned.
-You can use `verbose` option to have more informations, for now a dict with old and new value:
+By default, when you use ``get_dirty_fields`` function, if there are dirty fields, only the old value is returned.
+You can use ``verbose`` option to have more informations, for now a dict with old and new value:
 
 ::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -92,6 +92,26 @@ If you want to only save dirty fields from an instance in the database (only the
 Warning: this ``save_dirty_fields`` method will trigger the same signals as django default ``save`` method.
 But, in django 1.4.22-, as we are using under the hood an ``update`` method, we need to manually send these signals, so be aware that only ``sender`` and ``instance`` arguments are passed to the signal in that context.
 
+::
+
+    >>> tm.get_dirty_fields()
+    {'fkey': 1}
+    >>> tm.save_dirty_fields()
+    >>> tm.get_dirty_fields()
+    {}
+
+Verbose mode
+----------------------------
+By default, when you use ``get_dirty_fields` function, if there are dirty fields, only the old value is returned.
+You can use `verbose` option to have more informations, for now a dict with old and new value:
+
+::
+
+    >>> tm.get_dirty_fields()
+    {'fkey': 1}
+    >>> tm.get_dirty_fields(verbose=True)
+    {'fkey': {'saved': 1, 'current': 3}}
+
 
 Custom comparison function
 ----------------------------

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -54,7 +54,7 @@ class DirtyFieldsMixin(object):
 
         return all_field
 
-    def get_dirty_fields(self, check_relationship=False):
+    def get_dirty_fields(self, check_relationship=False, verbose=False):
         # check_relationship indicates whether we want to check for foreign keys
         # and one-to-one fields or ignore them
         new_state = self._as_dict(check_relationship)
@@ -64,7 +64,12 @@ class DirtyFieldsMixin(object):
             original_value = self._original_state[key]
 
             is_identical = self.compare_function[0](value, original_value, **self.compare_function[1])
-            if not is_identical:
+            if is_identical:
+                continue
+
+            if verbose:
+                all_modify_field[key] = {'saved': original_value, 'current': value}
+            else:
                 all_modify_field[key] = original_value
 
         return all_modify_field

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -127,3 +127,18 @@ def test_validationerror():
 
     tm.boolean = False
     assert tm.get_dirty_fields() == {'boolean': None}
+
+
+def test_verbose_mode():
+    tm = TestModel()
+
+    # initial state is dirty because it has not been saved yet in the db
+    assert tm.is_dirty()
+    assert tm.get_dirty_fields() == {}
+
+    # changing values should flag them as dirty
+    tm.boolean = False
+
+    assert tm.get_dirty_fields(verbose=True) == {
+        'boolean': {'saved': True, 'current': False}
+    }


### PR DESCRIPTION
Proposing `saved` and `current` keywords to be explicit about old and new value.

Related to issue #59 