### PR TITLE
Add compatibility for deprecated old _meta API

### DIFF
--- a/src/dirtyfields/compat.py
+++ b/src/dirtyfields/compat.py
@@ -4,6 +4,17 @@ from django.db.models import signals
 from django.db.models.query_utils import DeferredAttribute
 
 
+def get_m2m_with_model(given_model):
+    if django.VERSION < (1, 9):
+        return given_model._meta.get_m2m_with_model()
+    else:
+        return [
+            (f, f.model if f.model != given_model else None)
+            for f in given_model._meta.get_fields()
+            if f.many_to_many and not f.auto_created
+        ]
+
+
 def is_db_expression(value):
     try:
         # django < 1.8
@@ -44,7 +55,7 @@ def save_specific_fields(instance, fields_list):
 
 
 def is_buffer(value):
-    if sys.version_info < (3,0,0):
+    if sys.version_info < (3, 0, 0):
         return isinstance(value, buffer)
     else:
         return isinstance(value, memoryview)

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -6,7 +6,7 @@ from django.db.models.signals import post_save, m2m_changed
 
 from .compare import raw_compare, compare_states
 from .compat import (is_db_expression, save_specific_fields,
-                     is_deferred, is_buffer)
+                     is_deferred, is_buffer, get_m2m_with_model)
 
 
 class DirtyFieldsMixin(object):
@@ -22,7 +22,7 @@ class DirtyFieldsMixin(object):
         reset_state(sender=self.__class__, instance=self)
 
     def _connect_m2m_relations(self):
-        for m2m_field, model in self._meta.get_m2m_with_model():
+        for m2m_field, model in get_m2m_with_model(self.__class__):
             m2m_changed.connect(
                 reset_state, sender=m2m_field.rel.through,
                 dispatch_uid='{name}-DirtyFieldsMixin-sweeper-m2m'.format(
@@ -68,7 +68,7 @@ class DirtyFieldsMixin(object):
                 (f.attname, set([
                     obj.id for obj in getattr(self, f.attname).all()
                 ]))
-                for f, model in self._meta.get_m2m_with_model()
+                for f, model in get_m2m_with_model(self.__class__)
             ])
             return m2m_fields
         return {}


### PR DESCRIPTION
`_meta` API has changed in Django 1.9 and is now an official API.
Some equivalence has been given by the Django team: https://docs.djangoproject.com/en/1.9/ref/models/meta/
MR related to #69 