### PR TITLE
Replace id by pk to properly handle models with custom primary keys

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -69,7 +69,7 @@ class DirtyFieldsMixin(object):
         if self.pk:
             m2m_fields = dict([
                 (f.attname, set([
-                    obj.id for obj in getattr(self, f.attname).all()
+                    obj.pk for obj in getattr(self, f.attname).all()
                 ]))
                 for f, model in get_m2m_with_model(self.__class__)
             ])

--- a/tests/models.py
+++ b/tests/models.py
@@ -70,6 +70,14 @@ class TestM2MModel(DirtyFieldsMixin, models.Model):
     m2m_field = models.ManyToManyField(TestModel)
 
 
+class TestModelWithCustomPK(DirtyFieldsMixin, models.Model):
+    custom_primary_key = models.CharField(max_length=80, primary_key=True)
+
+
+class TestM2MModelWithCustomPKOnM2M(DirtyFieldsMixin, models.Model):
+    m2m_field = models.ManyToManyField(TestModelWithCustomPK)
+
+
 class TestModelWithPreSaveSignal(DirtyFieldsMixin, models.Model):
     data = models.CharField(max_length=10)
     data_updated_on_presave = models.CharField(max_length=10, blank=True, null=True)

--- a/tests/test_m2m_fields.py
+++ b/tests/test_m2m_fields.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .models import TestModel, TestM2MModel
+from .models import TestModel, TestM2MModel, TestModelWithCustomPK, TestM2MModelWithCustomPKOnM2M
 
 
 @pytest.mark.django_db
@@ -21,3 +21,14 @@ def test_dirty_fields_on_m2m():
 
     assert tm.get_dirty_fields(check_m2m={'m2m_field': set([0, tm2.id])}) == {'m2m_field': set([tm2.id])}
 
+
+@pytest.mark.django_db
+def test_m2m_check_with_custom_primary_key():
+    # test for bug: https://github.com/romgar/django-dirtyfields/issues/74
+
+    tm = TestModelWithCustomPK.objects.create(custom_primary_key='pk1')
+    m2m_model = TestM2MModelWithCustomPKOnM2M.objects.create()
+
+    # This line was triggering this error:
+    # AttributeError: 'TestModelWithCustomPK' object has no attribute 'id'
+    m2m_model.m2m_field.add(tm)


### PR DESCRIPTION
Related to #74 
We were using `.id` instead of `.pk`, which doesn't work as soon as the model has custom primary key.