### PR TITLE
Add an option to deactivate m2m checks, if not needed

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -88,9 +88,14 @@ Checking many-to-many fields.
 ----------------------------
 By default, dirty functions are not checking many-to-many fields. They are also a bit special, as a call to `.add()` method is directly
 saving the related object to the database, thus the instance is never dirty.
-You can still use ``check_m2m`` parameter, but you need to provide the values you want to test against:
+If you want to check these relations, you should set ``ENABLE_M2M_CHECK`` to ``True`` in your model inheriting from
+``DirtyFieldMixin``, use ``check_m2m`` parameter and provide the values you want to test against:
 
 ::
+
+    class TestM2MModel(DirtyFieldMixin, models.Model):
+        ENABLE_M2M_CHECK = True
+        m2m_field = models.ManyToManyField(AnotherModel)
 
     >>> from tests.models import TestM2MModel
     >>> tm = TestM2MModel.objects.create()
@@ -108,6 +113,9 @@ You can still use ``check_m2m`` parameter, but you need to provide the values yo
 
 This can be useful when validating forms with m2m relations, where you receive some ids and want to know if your object
 in the database needs to be updated with these form values.
+
+**WARNING**: this m2m mode will generate extra queries to get m2m relation values each time you will save your objects.
+It can have serious performance issues depending on your project.
 
 
 Saving dirty fields.

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -12,13 +12,18 @@ from .compat import (is_db_expression, save_specific_fields,
 class DirtyFieldsMixin(object):
     compare_function = (raw_compare, {})
 
+    # This mode has been introduced to handle some situations like this one:
+    # https://github.com/romgar/django-dirtyfields/issues/73
+    enable_m2m_check = True
+
     def __init__(self, *args, **kwargs):
         super(DirtyFieldsMixin, self).__init__(*args, **kwargs)
         post_save.connect(
             reset_state, sender=self.__class__,
             dispatch_uid='{name}-DirtyFieldsMixin-sweeper'.format(
                 name=self.__class__.__name__))
-        self._connect_m2m_relations()
+        if self.enable_m2m_check:
+            self._connect_m2m_relations()
         reset_state(sender=self.__class__, instance=self)
 
     def _connect_m2m_relations(self):
@@ -83,6 +88,9 @@ class DirtyFieldsMixin(object):
             initial_dict = self._as_dict(check_relationship, include_primary_key=False)
             return initial_dict
 
+        if check_m2m is not None and not self.enable_m2m_check:
+            raise Exception("You can't check m2m fields if enable_m2m_check is set to False")
+
         modified_fields = compare_states(self._as_dict(check_relationship),
                                          self._original_state,
                                          self.compare_function)
@@ -112,4 +120,5 @@ def reset_state(sender, instance, **kwargs):
     # original state should hold all possible dirty fields to avoid
     # getting a `KeyError` when checking if a field is dirty or not
     instance._original_state = instance._as_dict(check_relationship=True)
-    instance._original_m2m_state = instance._as_dict_m2m()
+    if instance.enable_m2m_check:
+        instance._original_m2m_state = instance._as_dict_m2m()

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -89,7 +89,7 @@ class DirtyFieldsMixin(object):
             return initial_dict
 
         if check_m2m is not None and not self.ENABLE_M2M_CHECK:
-            raise Exception("You can't check m2m fields if enable_m2m_check is set to False")
+            raise Exception("You can't check m2m fields if ENABLE_M2M_CHECK is set to False")
 
         modified_fields = compare_states(self._as_dict(check_relationship),
                                          self._original_state,

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -14,7 +14,7 @@ class DirtyFieldsMixin(object):
 
     # This mode has been introduced to handle some situations like this one:
     # https://github.com/romgar/django-dirtyfields/issues/73
-    ENABLE_M2M_CHECK = True
+    ENABLE_M2M_CHECK = False
 
     def __init__(self, *args, **kwargs):
         super(DirtyFieldsMixin, self).__init__(*args, **kwargs)

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -14,7 +14,7 @@ class DirtyFieldsMixin(object):
 
     # This mode has been introduced to handle some situations like this one:
     # https://github.com/romgar/django-dirtyfields/issues/73
-    enable_m2m_check = True
+    ENABLE_M2M_CHECK = True
 
     def __init__(self, *args, **kwargs):
         super(DirtyFieldsMixin, self).__init__(*args, **kwargs)
@@ -22,7 +22,7 @@ class DirtyFieldsMixin(object):
             reset_state, sender=self.__class__,
             dispatch_uid='{name}-DirtyFieldsMixin-sweeper'.format(
                 name=self.__class__.__name__))
-        if self.enable_m2m_check:
+        if self.ENABLE_M2M_CHECK:
             self._connect_m2m_relations()
         reset_state(sender=self.__class__, instance=self)
 
@@ -88,7 +88,7 @@ class DirtyFieldsMixin(object):
             initial_dict = self._as_dict(check_relationship, include_primary_key=False)
             return initial_dict
 
-        if check_m2m is not None and not self.enable_m2m_check:
+        if check_m2m is not None and not self.ENABLE_M2M_CHECK:
             raise Exception("You can't check m2m fields if enable_m2m_check is set to False")
 
         modified_fields = compare_states(self._as_dict(check_relationship),
@@ -120,5 +120,5 @@ def reset_state(sender, instance, **kwargs):
     # original state should hold all possible dirty fields to avoid
     # getting a `KeyError` when checking if a field is dirty or not
     instance._original_state = instance._as_dict(check_relationship=True)
-    if instance.enable_m2m_check:
+    if instance.ENABLE_M2M_CHECK:
         instance._original_m2m_state = instance._as_dict_m2m()

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -89,7 +89,7 @@ class DirtyFieldsMixin(object):
             return initial_dict
 
         if check_m2m is not None and not self.ENABLE_M2M_CHECK:
-            raise Exception("You can't check m2m fields if ENABLE_M2M_CHECK is set to False")
+            raise ValueError("You can't check m2m fields if ENABLE_M2M_CHECK is set to False")
 
         modified_fields = compare_states(self._as_dict(check_relationship),
                                          self._original_state,

--- a/tests/models.py
+++ b/tests/models.py
@@ -91,3 +91,8 @@ class TestModelWithPreSaveSignal(DirtyFieldsMixin, models.Model):
                 instance.data_updated_on_presave = 'presave_value'
 
 pre_save.connect(TestModelWithPreSaveSignal.pre_save, sender=TestModelWithPreSaveSignal)
+
+
+class TestModelWithoutM2MCheck(DirtyFieldsMixin, models.Model):
+    characters = models.CharField(blank=True, max_length=80)
+    ENABLE_M2M_CHECK = False

--- a/tests/models.py
+++ b/tests/models.py
@@ -68,6 +68,11 @@ class TestCurrentDatetimeModel(DirtyFieldsMixin, models.Model):
 
 class TestM2MModel(DirtyFieldsMixin, models.Model):
     m2m_field = models.ManyToManyField(TestModel)
+    ENABLE_M2M_CHECK = True
+
+
+class TestM2MModelWithoutM2MModeEnabled(DirtyFieldsMixin, models.Model):
+    m2m_field = models.ManyToManyField(TestModel)
 
 
 class TestModelWithCustomPK(DirtyFieldsMixin, models.Model):

--- a/tests/test_m2m_fields.py
+++ b/tests/test_m2m_fields.py
@@ -1,7 +1,7 @@
 import pytest
 
 from .models import TestModel, TestM2MModel, TestModelWithCustomPK, TestM2MModelWithCustomPKOnM2M, \
-    TestModelWithoutM2MCheck
+    TestModelWithoutM2MCheck, TestM2MModelWithoutM2MModeEnabled
 
 
 @pytest.mark.django_db
@@ -21,6 +21,16 @@ def test_dirty_fields_on_m2m():
     assert tm.get_dirty_fields(check_m2m={'m2m_field': set([0])}) == {'m2m_field': set([tm2.id])}
 
     assert tm.get_dirty_fields(check_m2m={'m2m_field': set([0, tm2.id])}) == {'m2m_field': set([tm2.id])}
+
+
+@pytest.mark.django_db
+def test_dirty_fields_on_m2m_not_possible_if_not_enabled():
+    tm = TestM2MModelWithoutM2MModeEnabled.objects.create()
+    tm2 = TestModel.objects.create()
+    tm.m2m_field.add(tm2)
+
+    with pytest.raises(Exception):
+        assert tm.get_dirty_fields(check_m2m={'m2m_field': set([tm2.id])}) == {}
 
 
 @pytest.mark.django_db

--- a/tests/test_m2m_fields.py
+++ b/tests/test_m2m_fields.py
@@ -1,6 +1,7 @@
 import pytest
 
-from .models import TestModel, TestM2MModel, TestModelWithCustomPK, TestM2MModelWithCustomPKOnM2M
+from .models import TestModel, TestM2MModel, TestModelWithCustomPK, TestM2MModelWithCustomPKOnM2M, \
+    TestModelWithoutM2MCheck
 
 
 @pytest.mark.django_db
@@ -32,3 +33,11 @@ def test_m2m_check_with_custom_primary_key():
     # This line was triggering this error:
     # AttributeError: 'TestModelWithCustomPK' object has no attribute 'id'
     m2m_model.m2m_field.add(tm)
+
+
+@pytest.mark.django_db
+def test_m2m_disabled_does_not_allow_to_check_m2m_fields():
+    tm = TestModelWithoutM2MCheck.objects.create()
+
+    with pytest.raises(Exception):
+        assert tm.get_dirty_fields(check_m2m={'dummy': True})

--- a/tests/test_m2m_fields.py
+++ b/tests/test_m2m_fields.py
@@ -29,7 +29,7 @@ def test_dirty_fields_on_m2m_not_possible_if_not_enabled():
     tm2 = TestModel.objects.create()
     tm.m2m_field.add(tm2)
 
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         assert tm.get_dirty_fields(check_m2m={'m2m_field': set([tm2.id])}) == {}
 
 


### PR DESCRIPTION
Related to #73 
Right now, m2m check is querying each relation, which can be quite inconvenient.
I propose to add a `ENABLE_M2M_CHECK` to be able to deactivate this functionality, if needed.