### PR TITLE
Add compatibility for Django 1.10 by updating deferred field handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - TOXENV=django17
   - TOXENV=django18
   - TOXENV=django19
+  - TOXENV=django110
   - TOXENV=coverage
 
 matrix:

--- a/src/dirtyfields/compare.py
+++ b/src/dirtyfields/compare.py
@@ -9,7 +9,13 @@ def compare_states(new_state, original_state, compare_function):
     modified_field = {}
 
     for key, value in new_state.items():
-        original_value = original_state[key]
+        try:
+            original_value = original_state[key]
+        except KeyError:
+            # In some situation, like deferred fields, it can happen that we try to compare the current
+            # state that has some fields not present in original state because of being initially deferred.
+            # We should not include them in the comparison.
+            continue
 
         is_identical = compare_function[0](value, original_value, **compare_function[1])
         if is_identical:

--- a/src/dirtyfields/compat.py
+++ b/src/dirtyfields/compat.py
@@ -26,9 +26,12 @@ def is_db_expression(value):
         return isinstance(value, (BaseExpression, Combinable))
 
 
-def is_deferred(model, field):
-    attr = model.__class__.__dict__.get(field.attname)
-    return isinstance(attr, DeferredAttribute)
+def is_deferred(instance, field):
+    if django.VERSION < (1, 8):
+        attr = instance.__class__.__dict__.get(field.attname)
+        return isinstance(attr, DeferredAttribute)
+    else:
+        return field.name in instance.get_deferred_fields()
 
 
 def save_specific_fields(instance, fields_list):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -114,6 +114,7 @@ def test_deferred_fields():
 
     tm = qs[0]
     tm.boolean = False
+
     assert tm.get_dirty_fields() == {'boolean': True}
 
     tm.characters = 'foo'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -114,7 +114,6 @@ def test_deferred_fields():
 
     tm = qs[0]
     tm.boolean = False
-
     assert tm.get_dirty_fields() == {'boolean': True}
 
     tm.characters = 'foo'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django14,django15,django16,django17,django18,django19,coverage
+envlist = django14,django15,django16,django17,django18,django19,django110,coverage
 
 [testenv]
 commands = py.test -v
@@ -37,6 +37,11 @@ deps =
 [testenv:django19]
 deps =
     django>=1.9,<1.9.99
+    {[testenv]deps}
+
+[testenv:django110]
+deps =
+    django>=1.10,<1.10.99
     {[testenv]deps}
 
 [testenv:coverage]


### PR DESCRIPTION
Deferred field behaviour has changed a bit in Django 1.10, which was causing errors (one example in #78).

Source code, tests and deployment process updated to take `1.10` version into account.