### PR TITLE
Add compat function to get field remote_field property (previously named rel)

### DIFF
--- a/src/dirtyfields/compat.py
+++ b/src/dirtyfields/compat.py
@@ -62,3 +62,10 @@ def is_buffer(value):
         return isinstance(value, buffer)
     else:
         return isinstance(value, memoryview)
+
+
+def remote_field(field):
+    if django.VERSION < (1, 9):
+        return field.rel
+    else:
+        return field.remote_field

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -6,7 +6,7 @@ from django.db.models.signals import post_save, m2m_changed
 
 from .compare import raw_compare, compare_states
 from .compat import (is_db_expression, save_specific_fields,
-                     is_deferred, is_buffer, get_m2m_with_model)
+                     is_deferred, is_buffer, get_m2m_with_model, remote_field)
 
 
 class DirtyFieldsMixin(object):
@@ -29,7 +29,7 @@ class DirtyFieldsMixin(object):
     def _connect_m2m_relations(self):
         for m2m_field, model in get_m2m_with_model(self.__class__):
             m2m_changed.connect(
-                reset_state, sender=m2m_field.rel.through,
+                reset_state, sender=remote_field(m2m_field).through,
                 dispatch_uid='{name}-DirtyFieldsMixin-sweeper-m2m'.format(
                     name=self.__class__.__name__))
 
@@ -40,7 +40,7 @@ class DirtyFieldsMixin(object):
             if field.primary_key and not include_primary_key:
                 continue
 
-            if field.rel:
+            if remote_field(field):
                 if not check_relationship:
                     continue
 


### PR DESCRIPTION
Add a compatibility function to access either `field.rel` or `field.remote_field` depending on Django version.

Related to #80 