### PR TITLE
Handle ForeignKey deferred fields to avoid RecursionErrors

### DIFF
--- a/src/dirtyfields/compat.py
+++ b/src/dirtyfields/compat.py
@@ -31,7 +31,7 @@ def is_deferred(instance, field):
         attr = instance.__class__.__dict__.get(field.attname)
         return isinstance(attr, DeferredAttribute)
     else:
-        return field.name in instance.get_deferred_fields()
+        return field.get_attname() in instance.get_deferred_fields()
 
 
 def save_specific_fields(instance, fields_list):

--- a/tests/models.py
+++ b/tests/models.py
@@ -105,4 +105,4 @@ class TestModelWithoutM2MCheck(DirtyFieldsMixin, models.Model):
 
 class TestDoubleForeignKeyModel(DirtyFieldsMixin, models.Model):
     fkey1 = models.ForeignKey(TestModel)
-    fkey2 = models.ForeignKey(TestModel, null=True)
+    fkey2 = models.ForeignKey(TestModel, null=True, related_name='fkey2')

--- a/tests/models.py
+++ b/tests/models.py
@@ -101,3 +101,8 @@ pre_save.connect(TestModelWithPreSaveSignal.pre_save, sender=TestModelWithPreSav
 class TestModelWithoutM2MCheck(DirtyFieldsMixin, models.Model):
     characters = models.CharField(blank=True, max_length=80)
     ENABLE_M2M_CHECK = False
+
+
+class TestDoubleForeignKeyModel(DirtyFieldsMixin, models.Model):
+    fkey1 = models.ForeignKey(TestModel)
+    fkey2 = models.ForeignKey(TestModel, null=True)

--- a/tests/test_non_regression.py
+++ b/tests/test_non_regression.py
@@ -5,7 +5,7 @@ from django.test.utils import override_settings
 
 from .models import (TestModel, TestModelWithForeignKey, TestModelWithNonEditableFields,
                      OrdinaryTestModel, OrdinaryTestModelWithForeignKey, TestModelWithSelfForeignKey,
-                     TestExpressionModel, TestModelWithPreSaveSignal)
+                     TestExpressionModel, TestModelWithPreSaveSignal, TestDoubleForeignKeyModel)
 from .utils import assert_select_number_queries_on_model
 
 
@@ -135,3 +135,13 @@ def test_pre_save_signal_make_dirty_checking_not_consistent():
     model.data = 'specific_value'
     model.save()
     assert model.data_updated_on_presave is 'presave_value'
+
+
+@pytest.mark.django_db
+def test_foreign_key_deferred_field():
+    # Non regression test case for bug:
+    # https://github.com/romgar/django-dirtyfields/issues/84
+    tm = TestModel.objects.create()
+    TestDoubleForeignKeyModel.objects.create(fkey1=tm)
+
+    list(TestDoubleForeignKeyModel.objects.only('fkey1'))  # RuntimeError was raised here!


### PR DESCRIPTION
`ForeignKey` deferred fields were not properly detected by `is_deferred` function.

Using `field.get_attname()` instead of `field.name` makes it more coherent with `model.get_deferred_fields()` built-in function.

Fixes #84.