### PR TITLE
Unmark dirty fields only listed in `update_fields` (if it was passed)

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -113,8 +113,20 @@ class DirtyFieldsMixin(object):
 
     def save_dirty_fields(self):
         dirty_fields = self.get_dirty_fields(check_relationship=True)
+        if not dirty_fields:
+            return False
         save_specific_fields(self, dirty_fields)
+        return True
 
+    def save_if_dirty(self, update_fields=None, *args, **kwargs):
+        if not self.is_dirty():
+            return False
+        if update_fields:
+            dirty_fields = self.get_dirty_fields().keys()
+            # check if even one listed field is dirty
+            if not set(update_fields) & set(dirty_fields):
+                return False
+        return self.save(update_fields=update_fields, *args, **kwargs)
 
 def reset_state(sender, instance, **kwargs):
     # original state should hold all possible dirty fields to avoid

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -119,6 +119,12 @@ class DirtyFieldsMixin(object):
 def reset_state(sender, instance, **kwargs):
     # original state should hold all possible dirty fields to avoid
     # getting a `KeyError` when checking if a field is dirty or not
-    instance._original_state = instance._as_dict(check_relationship=True)
+    update_fields = kwargs.pop('update_fields', {})
+    new_state = instance._as_dict(check_relationship=True)
+    if update_fields:
+        for field in update_fields:
+            instance._original_state[field] = new_state[field]
+    else:
+        instance._original_state = new_state
     if instance.ENABLE_M2M_CHECK:
         instance._original_m2m_state = instance._as_dict_m2m()

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -113,20 +113,8 @@ class DirtyFieldsMixin(object):
 
     def save_dirty_fields(self):
         dirty_fields = self.get_dirty_fields(check_relationship=True)
-        if not dirty_fields:
-            return False
         save_specific_fields(self, dirty_fields)
-        return True
 
-    def save_if_dirty(self, update_fields=None, *args, **kwargs):
-        if not self.is_dirty():
-            return False
-        if update_fields:
-            dirty_fields = self.get_dirty_fields().keys()
-            # check if even one listed field is dirty
-            if not set(update_fields) & set(dirty_fields):
-                return False
-        return self.save(update_fields=update_fields, *args, **kwargs)
 
 def reset_state(sender, instance, **kwargs):
     # original state should hold all possible dirty fields to avoid


### PR DESCRIPTION
The problem:
after calling `instance.save(update_fields=['something'])` if something else was dirty it becomes clean

My code solves this problem.

Sorry, I didn't get how to set up testing (tox) on local machine -- it threw errors (before my code was written).
But I've tested this code in my project -- everything was good.