### PR TITLE
Unmark dirty fields only listed in `update_fields` (if it was passed)

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -119,6 +119,12 @@ class DirtyFieldsMixin(object):
 def reset_state(sender, instance, **kwargs):
     # original state should hold all possible dirty fields to avoid
     # getting a `KeyError` when checking if a field is dirty or not
-    instance._original_state = instance._as_dict(check_relationship=True)
+    update_fields = kwargs.pop('update_fields', {})
+    new_state = instance._as_dict(check_relationship=True)
+    if update_fields:
+        for field in update_fields:
+            instance._original_state[field] = new_state[field]
+    else:
+        instance._original_state = new_state
     if instance.ENABLE_M2M_CHECK:
         instance._original_m2m_state = instance._as_dict_m2m()


### PR DESCRIPTION
The problem:
after calling instance.save(update_fields=['something']) if something else was dirty it becomes clean

My code solves this problem.

Sorry, I didn't get how to set up testing (tox) on local machine -- it threw errors (before my code was written).
But I've tested this code in my project -- everything was good.

P.S. This is clear PR (previous is #90). Sorry for that PR-mess ;)