### PR TITLE
Use attname on foreign key fields

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -64,9 +64,12 @@ class DirtyFieldsMixin(object):
                 # psycopg2 returns uncopyable type buffer for bytea
                 field_value = str(field_value)
 
+            # Use the column name (instead of the relationship name) if it's a
+            # foreign key.
+            key = field.attname if hasattr(field, 'attname') else field.name
             # Explanation of copy usage here :
             # https://github.com/romgar/django-dirtyfields/commit/efd0286db8b874b5d6bd06c9e903b1a0c9cc6b00
-            all_field[field.name] = deepcopy(field_value)
+            all_field[key] = deepcopy(field_value)
 
         return all_field
 


### PR DESCRIPTION
I was consistently hitting an error when re-saving an existing object on django 1.10. Specifically I was getting a KeyError at https://github.com/romgar/django-dirtyfields/blob/develop/src/dirtyfields/dirtyfields.py#L127 - new_state had the foreign key object name (e.g. `post`), but original_state had the foreign key _id field (e.g. `post_id`)

I hit this when updating an app to django 1.10, but I'm surprised no one else has run into this, so it's quite possible it's a local error only. I thought it would be nice to document it at least. I think it may be related to the issue seen in #37