### PR TITLE
Verbose mode on adding

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -88,6 +88,9 @@ class DirtyFieldsMixin(object):
             # for consistency (see https://github.com/romgar/django-dirtyfields/issues/65 for more details)
             pk_specified = self.pk is not None
             initial_dict = self._as_dict(check_relationship, include_primary_key=pk_specified)
+            if verbose:
+                initial_dict = {key: {'saved': value, 'current': None}
+                                for key, value in initial_dict.items()}
             return initial_dict
 
         if check_m2m is not None and not self.ENABLE_M2M_CHECK:

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -89,7 +89,7 @@ class DirtyFieldsMixin(object):
             pk_specified = self.pk is not None
             initial_dict = self._as_dict(check_relationship, include_primary_key=pk_specified)
             if verbose:
-                initial_dict = {key: {'saved': value, 'current': None}
+                initial_dict = {key: {'saved': None, 'current': value}
                                 for key, value in initial_dict.items()}
             return initial_dict
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -160,5 +160,5 @@ def test_verbose_mode_on_adding():
     tm = TestModel()
 
     assert tm.get_dirty_fields(verbose=True) == {
-        'boolean': {'saved': True, 'current': None}
+        'boolean': {'saved': None, 'current': True}
     }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -160,5 +160,6 @@ def test_verbose_mode_on_adding():
     tm = TestModel()
 
     assert tm.get_dirty_fields(verbose=True) == {
-        'boolean': {'saved': None, 'current': True}
+        'boolean': {'saved': None, 'current': True},
+        'characters': {'saved': None, 'current': u''}
     }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -153,3 +153,12 @@ def test_verbose_mode():
     assert tm.get_dirty_fields(verbose=True) == {
         'boolean': {'saved': True, 'current': False}
     }
+
+
+@pytest.mark.django_db
+def test_verbose_mode_on_adding():
+    tm = TestModel()
+
+    assert tm.get_dirty_fields(verbose=True) == {
+        'boolean': {'saved': True, 'current': None}
+    }


### PR DESCRIPTION
Right now `get_dirty_fields(verbose=True)` for not saved object returns dict like in case `verbose=False` (only with old values). This PR allows to have the same format of result regardless of adding state. 