### PR TITLE
Refs #104: Handle FK _id field name

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -11,6 +11,10 @@ master (unreleased)
     - Drop support for unsupported Django versions: 1.4, 1.5, 1.6 and 1.7 series.
     - Fixes issue with verbose mode when the object has not been yet saved in the database (MR #99). Thanks vapkarian.
 
+*Bugfix:*
+
+    - Correctly handle :code:`ForeignKey.db_column` :code:`{}_id` in :code:`update_fields`
+
 
 .. _v1.2.1:
 

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -127,8 +127,9 @@ def reset_state(sender, instance, **kwargs):
     update_fields = kwargs.pop('update_fields', {})
     new_state = instance._as_dict(check_relationship=True)
     if update_fields:
-        for field in update_fields:
-            instance._original_state[field] = new_state[field]
+        for field_name in update_fields:
+            field = sender._meta.get_field(field_name)
+            instance._original_state[field.name] = new_state[field.name]
     else:
         instance._original_state = new_state
     if instance.ENABLE_M2M_CHECK:

--- a/tests/test_save_fields.py
+++ b/tests/test_save_fields.py
@@ -3,7 +3,7 @@ import unittest
 import django
 import pytest
 
-from .models import TestModel, TestMixedFieldsModel
+from .models import TestModel, TestMixedFieldsModel, TestModelWithForeignKey
 from .utils import assert_number_of_queries_on_regex
 
 
@@ -67,3 +67,29 @@ def test_save_only_specific_fields_should_let_other_fields_dirty():
 
     # 'characters' field should still be dirty, update_fields was only saving the 'boolean' field in the db
     assert tm.get_dirty_fields() == {'characters': 'dummy'}
+
+
+@pytest.mark.django_db
+def test_handle_foreignkeys_id_field_in_update_fields():
+    tm1 = TestModel.objects.create(boolean=True, characters='dummy')
+    tm2 = TestModel.objects.create(boolean=True, characters='dummy')
+    tmwfk = TestModelWithForeignKey.objects.create(fkey=tm1)
+
+    tmwfk.fkey = tm2
+    assert tmwfk.get_dirty_fields(check_relationship=True) == {'fkey': tm1.pk}
+
+    tmwfk.save(update_fields=['fkey_id'])
+    assert tmwfk.get_dirty_fields(check_relationship=True) == {}
+
+
+@pytest.mark.django_db
+def test_correctly_handle_foreignkeys_id_field_in_update_fields():
+    tm1 = TestModel.objects.create(boolean=True, characters='dummy')
+    tm2 = TestModel.objects.create(boolean=True, characters='dummy')
+    tmwfk = TestModelWithForeignKey.objects.create(fkey=tm1)
+
+    tmwfk.fkey_id = tm2.pk
+    assert tmwfk.get_dirty_fields(check_relationship=True) == {'fkey': tm1.pk}
+
+    tmwfk.save(update_fields=['fkey'])
+    assert tmwfk.get_dirty_fields(check_relationship=True) == {}


### PR DESCRIPTION
Here is a fix to handle foreign keys _id field names.