### PR TITLE
Add coverage for django 1 11

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -10,10 +10,12 @@ master (unreleased)
 
     - Drop support for unsupported Django versions: 1.4, 1.5, 1.6 and 1.7 series.
     - Fixes issue with verbose mode when the object has not been yet saved in the database (MR #99). Thanks vapkarian.
+    - Add test coverage for Django 1.11.
+
 
 *Bugfix:*
 
-    - Correctly handle :code:`ForeignKey.db_column` :code:`{}_id` in :code:`update_fields`
+    - Correctly handle :code:`ForeignKey.db_column` :code:`{}_id` in :code:`update_fields`. Thanks Hugo Smett.
 
 
 .. _v1.2.1:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django18,django19,django110,coverage,postgresql
+envlist = django18,django19,django110,django111,coverage,postgresql
 
 [testenv]
 setenv =
@@ -27,13 +27,18 @@ deps =
     django>=1.10,<1.10.99
     {[testenv]deps}
 
+[testenv:django111]
+deps =
+    django>=1.11,<1.11.99
+    {[testenv]deps}
+
 [testenv:postgresql]
 setenv =
     PYTHONPATH = {toxinidir}
 commands =
     py.test --ds=tests.postgresql_django_settings -v
 deps =
-    django>=1.10,<1.10.99
+    django>=1.11,<1.11.99
     psycopg2
     {[testenv]deps}
 


### PR DESCRIPTION
Update tox configuration to add Django `1.11` in test coverage. Fixes #109 