### PR TITLE
Fix memory leak

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -16,6 +16,7 @@ master (unreleased)
 *Bugfix:*
 
     - Correctly handle :code:`ForeignKey.db_column` :code:`{}_id` in :code:`update_fields`. Thanks Hugo Smett.
+    - Fixes #111: Eliminate a memory leak.
 
 
 .. _v1.2.1:

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -20,7 +20,7 @@ class DirtyFieldsMixin(object):
     def __init__(self, *args, **kwargs):
         super(DirtyFieldsMixin, self).__init__(*args, **kwargs)
         post_save.connect(
-            reset_state, sender=self.__class__,
+            reset_state, sender=self.__class__, weak=False,
             dispatch_uid='{name}-DirtyFieldsMixin-sweeper'.format(
                 name=self.__class__.__name__))
         if self.ENABLE_M2M_CHECK:
@@ -30,7 +30,7 @@ class DirtyFieldsMixin(object):
     def _connect_m2m_relations(self):
         for m2m_field, model in get_m2m_with_model(self.__class__):
             m2m_changed.connect(
-                reset_state, sender=remote_field(m2m_field).through,
+                reset_state, sender=remote_field(m2m_field).through, weak=False,
                 dispatch_uid='{name}-DirtyFieldsMixin-sweeper-m2m'.format(
                     name=self.__class__.__name__))
 

--- a/tests/test_memory_leak.py
+++ b/tests/test_memory_leak.py
@@ -1,0 +1,16 @@
+import resource
+
+import pytest
+
+from .models import TestModel as DirtyMixinModel
+
+pytestmark = pytest.mark.django_db
+
+
+def test_rss_usage():
+    DirtyMixinModel()
+    rss_1 = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    for _ in range(1000):
+        DirtyMixinModel()
+    rss_2 = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    assert rss_2 == rss_1, 'There is a memory leak!'


### PR DESCRIPTION
As I can see there is no reason of using weak reference of `reset_state` receiver in `post_save` signal.
This function (`reset_state`) will never be deleted or collected by `gc`. 
Additionally every weak referenced receiver [ends up](https://github.com/django/django/blob/3eb679a86956d9eedf24492f0002de002f7180f5/django/dispatch/dispatcher.py#L97-L106) in `weakref.finilize.registiry` [[link]](https://github.com/python/cpython/blob/2e576f5aec1f8f23f07001e2eb3db9276851a4fc/Lib/weakref.py#L540).
It means every object initialisation increases memory consumption.

Please consider following example:

```python
# simple django model without DirtyFields mixin
>>> resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
79340
>>> timeit.timeit(SimpleModel, number=10000)
0.77
>>> resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
79340  # rss didn't change


# model with DirtyFields mixin
>>> timeit.timeit(ModelWithDirtyFieldsMixin, number=10000)
10.03
>>> resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
83308    # memory usage increased
```