### PR TITLE
Fixes #113 Respect FIELDS_TO_CHECK in reset_state

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -133,14 +133,17 @@ def reset_state(sender, instance, **kwargs):
     # getting a `KeyError` when checking if a field is dirty or not
     update_fields = kwargs.pop('update_fields', {})
     new_state = instance._as_dict(check_relationship=True)
+    FIELDS_TO_CHECK = getattr(instance, "FIELDS_TO_CHECK", None)
     if update_fields:
         for field_name in update_fields:
             field = sender._meta.get_field(field_name)
+            if not FIELDS_TO_CHECK or \
+                    (field.get_attname() in FIELDS_TO_CHECK):
 
-            if field.get_attname() in instance.get_deferred_fields():
-                continue
+                if field.get_attname() in instance.get_deferred_fields():
+                    continue
 
-            instance._original_state[field.name] = new_state[field.name]
+                instance._original_state[field.name] = new_state[field.name]
 
     else:
         instance._original_state = new_state

--- a/tests/models.py
+++ b/tests/models.py
@@ -125,6 +125,13 @@ class TestModelWithSpecifiedFields(DirtyFieldsMixin, models.Model):
     FIELDS_TO_CHECK = ['boolean1']
 
 
+class TestModelWithSpecifiedFieldsAndForeignKey(DirtyFieldsMixin, models.Model):
+    boolean1 = models.BooleanField(default=True)
+    boolean2 = models.BooleanField(default=True)
+    fk_field = models.OneToOneField(TestModel, null=True)
+    FIELDS_TO_CHECK = ['fk_field_id']
+
+
 class TestModelWithM2MAndSpecifiedFields(DirtyFieldsMixin, models.Model):
     m2m1 = models.ManyToManyField(TestModel)
     m2m2 = models.ManyToManyField(TestModel)

--- a/tests/test_specified_fields.py
+++ b/tests/test_specified_fields.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .models import TestModel, TestModelWithSpecifiedFields, TestModelWithM2MAndSpecifiedFields
+from .models import TestModel, TestModelWithSpecifiedFields, TestModelWithM2MAndSpecifiedFields, TestModelWithSpecifiedFieldsAndForeignKey
 
 
 @pytest.mark.django_db
@@ -26,3 +26,31 @@ def test_dirty_fields_on_model_with_m2m_and_specified_fields():
     assert tm.get_dirty_fields(check_m2m={'m2m1': set([])}) == {'m2m1': set([tm2.id])}
     assert tm.get_dirty_fields(check_m2m={'m2m2': set([])}) == {}
 
+@pytest.mark.django_db
+def test_dirty_fields_on_model_with_specified_fields_can_save_when_non_tracked_field_is_modified():
+    tm = TestModelWithSpecifiedFields.objects.create()
+
+    tm.boolean1 = False
+    tm.boolean2 = False
+
+    tm.save(update_fields=["boolean2"])
+
+    assert "boolean1" in tm._original_state
+    assert "boolean2" not in tm._original_state
+
+
+@pytest.mark.django_db
+def test_dirty_fields_on_model_with_specified_fields_can_save_when_non_tracked_fk_field_is_modified():
+    tm = TestModelWithSpecifiedFieldsAndForeignKey.objects.create()
+    fk = TestModel.objects.create()
+    tm.fk_field = fk
+    tm.boolean1 = False
+    tm.boolean2 = False
+
+    tm.save(update_fields=["fk_field"])
+    assert "fk_field" in tm._original_state
+
+    tm.boolean2 = True
+    tm.save()
+    assert "fk_field" in tm._original_state
+    assert "boolean2" not in tm._original_state


### PR DESCRIPTION
This prevents a problem when using the
update_fields parameter of .save() where you
pass a field that is not in the FIELDS_TO_CHECK
list.