### PR TITLE
DirtyFieldsMixin._as_dict now calls get_deferred_fields only once

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -39,6 +39,8 @@ class DirtyFieldsMixin(object):
     def _as_dict(self, check_relationship, include_primary_key=True):
         all_field = {}
 
+        deferred_fields = self.get_deferred_fields()
+
         for field in self._meta.fields:
             if self.FIELDS_TO_CHECK and (field.get_attname() not in self.FIELDS_TO_CHECK):
                 continue
@@ -50,7 +52,7 @@ class DirtyFieldsMixin(object):
                 if not check_relationship:
                     continue
 
-            if field.get_attname() in self.get_deferred_fields():
+            if field.get_attname() in deferred_fields:
                 continue
 
             field_value = getattr(self, field.attname)


### PR DESCRIPTION
I have some pages taking minutes to load due to thousands calls to get_deferred_fields.
