### PR TITLE
Add pep8 validation using flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - TOXENV=django110
   - TOXENV=coverage
   - TOXENV=postgresql
+  - TOXENV=flake8
 
 services:
   - postgresql

--- a/src/dirtyfields/__init__.py
+++ b/src/dirtyfields/__init__.py
@@ -1,2 +1,4 @@
 from __future__ import absolute_import
 from dirtyfields.dirtyfields import DirtyFieldsMixin
+
+__all__ = ['DirtyFieldsMixin']

--- a/src/dirtyfields/compat.py
+++ b/src/dirtyfields/compat.py
@@ -15,7 +15,7 @@ def get_m2m_with_model(given_model):
 
 def is_buffer(value):
     if sys.version_info < (3, 0, 0):
-        return isinstance(value, buffer)
+        return isinstance(value, buffer)  # noqa
     else:
         return isinstance(value, memoryview)
 

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -90,7 +90,6 @@ class DirtyFieldsMixin(object):
 
         return m2m_fields
 
-
     def get_dirty_fields(self, check_relationship=False, check_m2m=None, verbose=False):
         if self._state.adding:
             # If the object has not yet been saved in the database, all fields are considered dirty

--- a/tests/django_settings.py
+++ b/tests/django_settings.py
@@ -4,7 +4,7 @@ SECRET_KEY = 'WE DONT CARE ABOUT IT'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
+        'ENGINE': 'django.db.backends.sqlite3',  # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
         'NAME': 'dirtyfields.db',                      # Or path to database file if using sqlite3.
         'USER': '',                      # Not used with sqlite3.
         'PASSWORD': '',                  # Not used with sqlite3.

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,5 +1,3 @@
-import django
-
 from django.db import models
 from django.db.models.signals import pre_save
 from django.utils import timezone
@@ -99,7 +97,9 @@ class TestModelWithPreSaveSignal(DirtyFieldsMixin, models.Model):
             if 'specific_value' in instance.data:
                 instance.data_updated_on_presave = 'presave_value'
 
-pre_save.connect(TestModelWithPreSaveSignal.pre_save, sender=TestModelWithPreSaveSignal)
+
+pre_save.connect(TestModelWithPreSaveSignal.pre_save,
+                 sender=TestModelWithPreSaveSignal)
 
 
 class TestModelWithoutM2MCheck(DirtyFieldsMixin, models.Model):
@@ -130,4 +130,3 @@ class TestModelWithM2MAndSpecifiedFields(DirtyFieldsMixin, models.Model):
     m2m2 = models.ManyToManyField(TestModel)
     ENABLE_M2M_CHECK = True
     FIELDS_TO_CHECK = ['m2m1']
-

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,7 +5,6 @@ from .models import (TestModel, TestModelWithForeignKey, TestModelWithOneToOneFi
                      SubclassModel, TestModelWithDecimalField)
 
 
-
 @pytest.mark.django_db
 def test_is_dirty_function():
     tm = TestModel.objects.create()

--- a/tests/test_non_regression.py
+++ b/tests/test_non_regression.py
@@ -65,7 +65,7 @@ def test_relationship_model_loading_issue():
                 tmf.fkey  # access the relationship here
 
     with assert_select_number_queries_on_model(OrdinaryTestModelWithForeignKey, 1):
-        with assert_select_number_queries_on_model(OrdinaryTestModel, 0): # should be 0 since we use `select_related`
+        with assert_select_number_queries_on_model(OrdinaryTestModel, 0):  # should be 0 since we use `select_related`
             for tmf in OrdinaryTestModelWithForeignKey.objects.select_related('fkey').all():
                 tmf.fkey  # access the relationship here
 

--- a/tests/test_save_fields.py
+++ b/tests/test_save_fields.py
@@ -1,5 +1,3 @@
-import unittest
-
 import django
 import pytest
 
@@ -104,6 +102,7 @@ def test_save_deferred_field_with_update_fields():
     # save parameter doesn't raise a KeyError anymore.
     tm.save(update_fields=['boolean'])
 
+
 @pytest.mark.django_db
 def test_deferred_field_was_not_dirty():
     TestModel.objects.create()
@@ -111,10 +110,12 @@ def test_deferred_field_was_not_dirty():
     tm.boolean = False
     assert tm.get_dirty_fields() == {}
 
+
 @pytest.mark.django_db
-def test_save_deferred_field_with_update_fields():
-    """ Behavoir of Deferred fields have change in django 1.10. This tests
-    reflects this differents behavior.
+def test_save_deferred_field_with_update_fields_behaviour():
+    """ Behaviour of deferred fields has changed in Django 1.10.
+    Once explicitly updated (using the save update_fields parameter),
+    a field cannot be considered deferred anymore.
     """
 
     TestModel.objects.create()

--- a/tests/test_specified_fields.py
+++ b/tests/test_specified_fields.py
@@ -25,4 +25,3 @@ def test_dirty_fields_on_model_with_m2m_and_specified_fields():
     # m2m1 is tracked, m2m2 isn`t tracked
     assert tm.get_dirty_fields(check_m2m={'m2m1': set([])}) == {'m2m1': set([tm2.id])}
     assert tm.get_dirty_fields(check_m2m={'m2m2': set([])}) == {}
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,15 @@
 [tox]
-envlist = django18,django19,django110,django111,coverage,postgresql
+envlist =
+    django18
+    django19
+    django110
+    django111
+    coverage
+    postgresql
+    flake8
+
+[flake8]
+ignore = E501
 
 [testenv]
 setenv =
@@ -47,3 +57,9 @@ commands = coverage run --source dirtyfields -m py.test --ds=tests.django_settin
 deps =
     coverage
     {[testenv:django110]deps}
+
+[testenv:flake8]
+deps = flake8
+commands =
+    python --version
+    flake8 src tests


### PR DESCRIPTION
```
src/dirtyfields/__init__.py:2:1: F401 'dirtyfields.dirtyfields.DirtyFieldsMixin' imported but unused
src/dirtyfields/dirtyfields.py:94:5: E303 too many blank lines (2)
tests/test_save_fields.py:1:1: F401 'unittest' imported but unused
tests/test_save_fields.py:107:1: E302 expected 2 blank lines, found 1
tests/test_save_fields.py:114:1: E302 expected 2 blank lines, found 1
tests/test_save_fields.py:114:1: F811 redefinition of unused 'test_save_deferred_field_with_update_fields' from line 97
tests/django_settings.py:7:48: E261 at least two spaces before inline comment
tests/test_non_regression.py:68:74: E261 at least two spaces before inline comment
tests/models.py:1:1: F401 'django' imported but unused
tests/models.py:102:1: E305 expected 2 blank lines after class or function definition, found 1
tests/models.py:133:1: W391 blank line at end of file
tests/test_specified_fields.py:28:1: W391 blank line at end of file
tests/test_core.py:9:1: E303 too many blank lines (3)
```