### PR TITLE
Add a non regression test to deal with buffer types

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -70,7 +70,7 @@ class DirtyFieldsMixin(object):
 
             if is_buffer(field_value):
                 # psycopg2 returns uncopyable type buffer for bytea
-                field_value = str(field_value)
+                field_value = bytes(field_value)
 
             # Explanation of copy usage here :
             # https://github.com/romgar/django-dirtyfields/commit/efd0286db8b874b5d6bd06c9e903b1a0c9cc6b00

--- a/tests/models.py
+++ b/tests/models.py
@@ -137,3 +137,7 @@ class TestModelWithM2MAndSpecifiedFields(DirtyFieldsMixin, models.Model):
     m2m2 = models.ManyToManyField(TestModel)
     ENABLE_M2M_CHECK = True
     FIELDS_TO_CHECK = ['m2m1']
+
+
+class TestBinaryModel(DirtyFieldsMixin, models.Model):
+    bytea = models.BinaryField()

--- a/tests/test_non_regression.py
+++ b/tests/test_non_regression.py
@@ -1,5 +1,4 @@
 import pytest
-from base64 import b64encode
 from django.db import IntegrityError
 from django.test.utils import override_settings
 
@@ -150,9 +149,9 @@ def test_foreign_key_deferred_field():
 
 @pytest.mark.django_db
 def test_bytea():
-    TestBinaryModel.objects.create(bytea=b64encode(b'Hello'))
+    TestBinaryModel.objects.create(bytea=b'^H\xc3\xabllo')
     tbm = TestBinaryModel.objects.get()
     tbm.bytea = b'W\xc3\xb6rlD'
     assert tbm.get_dirty_fields() == {
-        'bytea': b'SGVsbG8=',
+        'bytea': b'^H\xc3\xabllo',
     }


### PR DESCRIPTION
Python 2.7:
```python
>>> str(buffer(b"I'm binary"))
"I'm binary"
>>> bytes(buffer(b"I'm binary"))
"I'm binary"
```

Python 3.6:
```python
>>> str(memoryview(b"I'm binary"))
'<memory at 0x7fd84fc27648>'
>>> bytes(memoryview(b"I'm binary"))
b"I'm binary"
```
