### PR TITLE
Reset state on refresh_from_db calls

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -29,6 +29,10 @@ class DirtyFieldsMixin(object):
             self._connect_m2m_relations()
         reset_state(sender=self.__class__, instance=self)
 
+    def refresh_from_db(self, *a, **kw):
+        super(DirtyFieldsMixin, self).refresh_from_db(*a, **kw)
+        reset_state(sender=self.__class__, instance=self)
+
     def _connect_m2m_relations(self):
         for m2m_field, model in get_m2m_with_model(self.__class__):
             m2m_changed.connect(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -162,3 +162,14 @@ def test_verbose_mode_on_adding():
         'boolean': {'saved': None, 'current': True},
         'characters': {'saved': None, 'current': u''}
     }
+
+
+@pytest.mark.django_db
+def test_refresh_from_db():
+    tm = TestModel.objects.create()
+    alias = TestModel.objects.get(pk=tm.pk)
+    alias.boolean = False
+    alias.save()
+
+    tm.refresh_from_db()
+    assert tm.get_dirty_fields() == {}


### PR DESCRIPTION
Calling refresh_from_db should always results in clean fields.