### PR TITLE
Add mention of _id postfix of fk fields

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,7 +60,7 @@ Examples
 
 Checking foreign key fields.
 ----------------------------
-By default, dirty functions are not checking foreign keys. If you want to also take these relationships into account, use ``check_relationship`` parameter:
+By default, dirty functions are not checking foreign keys. If you want to also take these relationships into account, use ``check_relationship`` parameter. Notice that the foreign key is specified only by its id, ``<fkname>_id``, since the relation might be deleted in the meantime.
 
 ::
 
@@ -81,7 +81,7 @@ By default, dirty functions are not checking foreign keys. If you want to also t
     >>> tm.get_dirty_fields()
     {}
     >>> tm.get_dirty_fields(check_relationship=True)
-    {'fkey': 1}
+    {'fkey_id': 1}
 
 
 Checking many-to-many fields.


### PR DESCRIPTION
Am not quite sure what the intended behavior is, but the docs do not seem to mention that the dirty fields dict is populated only by the raw ID fields of a foreign key.