### PR TITLE
Added normalise_function to provide control on how dirty values are stored

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -191,6 +191,30 @@ You can now define how you want to compare 2 values by passing a function on Dir
 
 Have a look at ``dirtyfields.compare`` module to get some examples.
 
+Custom value normalisation function
+----------------------------
+By default, ``dirtyfields`` reports on the dirty fields as is. If a date field was changed
+the result of ``get_dirty_fields`` will return the current and saved datetime object.
+In some cases it is useful to normalise those values, e.g., when wanting ot save the diff data as a json dataset in a database.
+The default behaviour of using values as is can be changed by providing a ``normalise_function``
+in your model. That function can evaluate the value's type and rewrite it accordingly.
+
+::
+
+    import datetime
+    from django.db import models
+    from dirtyfields import DirtyFieldsMixin
+
+    def your_normalise_function(value):
+        if isinstance(value, (datetime.datetime, datetime.date)):
+            return value.isoformat()
+        else:
+            return value
+
+    class TestModel(DirtyFieldsMixin, models.Model):
+        normalise_function = (your_normalise_function, {'extra_kwargs': 1})
+
+
 Why would you want this?
 ========================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -199,20 +199,29 @@ In some cases it is useful to normalise those values, e.g., when wanting ot save
 The default behaviour of using values as is can be changed by providing a ``normalise_function``
 in your model. That function can evaluate the value's type and rewrite it accordingly.
 
-::
+This example shows the usage of the normalise function, with an extra paramter of a user's timezone
+being passed as well:
 
+::
+    import pytz
     import datetime
     from django.db import models
     from dirtyfields import DirtyFieldsMixin
 
-    def your_normalise_function(value):
+    def your_normalise_function(value, timezone=None):
         if isinstance(value, (datetime.datetime, datetime.date)):
-            return value.isoformat()
+            if timezone:
+                return pytz.timezone(timezone).localize(value).isoformat()
+            else:
+                return value.isoformat()
         else:
             return value
 
+    def get_user_timezone():
+        return 'Europe/London'
+
     class TestModel(DirtyFieldsMixin, models.Model):
-        normalise_function = (your_normalise_function, {'extra_kwargs': 1})
+        normalise_function = (your_normalise_function, {'timezone': get_user_timezone()})
 
 
 Why would you want this?

--- a/src/dirtyfields/compare.py
+++ b/src/dirtyfields/compare.py
@@ -5,7 +5,7 @@ import warnings
 from django.utils import timezone
 
 
-def compare_states(new_state, original_state, compare_function):
+def compare_states(new_state, original_state, compare_function, normalise_function):
     modified_field = {}
 
     for key, value in new_state.items():
@@ -21,7 +21,10 @@ def compare_states(new_state, original_state, compare_function):
         if is_identical:
             continue
 
-        modified_field[key] = {'saved': original_value, 'current': value}
+        modified_field[key] = {
+            'saved': normalise_function[0](original_value, **normalise_function[1]),
+            'current': normalise_function[0](value, **normalise_function[1])
+        }
 
     return modified_field
 
@@ -56,3 +59,13 @@ def timezone_support_compare(new_value, old_value, timezone_to_set=pytz.UTC):
         old_value = timezone.make_aware(old_value, pytz.utc).astimezone(timezone_to_set)
 
     return raw_compare(new_value, old_value)
+
+
+def normalise_value(value):
+    """
+    Default normalisation of value simply returns the value as is.
+    Custom implementations can normalise the value for various storage schemes.
+    For example, converting datetime objects to iso datetime strings in order to
+    comply with JSON standard.
+    """
+    return value


### PR DESCRIPTION
In some cases, it's useful to store the dirty fields as an audit in various storage mechanisms such as a postgres jsonb column. Some values will not serialise to JSON and this PR allows the client to supply a function that will normalise the values into a format that can be serialised. 

```
import datetime
    from django.db import models
    from dirtyfields import DirtyFieldsMixin

    def your_normalise_function(value):
        if isinstance(value, (datetime.datetime, datetime.date)):
            return value.isoformat()
        else:
            return value

    class TestModel(DirtyFieldsMixin, models.Model):
        normalise_function = (your_normalise_function, {'extra_kwargs': 1})

```