### PR TITLE
Support disable_dirtyfields on queryset

### DIFF
--- a/src/dirtyfields/decorators.py
+++ b/src/dirtyfields/decorators.py
@@ -1,0 +1,22 @@
+import functools
+from .exceptions import DirtyFieldsDisabled
+
+
+def require_non_disabled(func):
+    """Decorator to use on methods that should not be used when dirtyfields
+    is disabled. It will raise an error when that happens.
+
+    """
+
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        if self._dirtyfields_disabled:
+            # Get the bound method from the current object to get better log information
+            func_log = getattr(self, func.__name__)
+            raise DirtyFieldsDisabled(
+                f'Dirtyfields is disabled and is being used: unsafe operation - {func_log}'
+            )
+
+        return func(self, *args, **kwargs)
+
+    return wrapper

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -1,13 +1,52 @@
 # Adapted from http://stackoverflow.com/questions/110803/dirty-fields-in-django
 from copy import deepcopy
+import logging
 
 from django.core.exceptions import ValidationError
+from django.db import models
+from django.db.models import DEFERRED
 from django.db.models.expressions import BaseExpression
 from django.db.models.expressions import Combinable
 from django.db.models.signals import post_save, m2m_changed
 
 from .compare import raw_compare, compare_states, normalise_value
 from .compat import is_buffer, get_m2m_with_model, remote_field
+from .decorators import require_non_disabled
+
+
+log = logging.getLogger(__name__)
+
+
+class DirtyFieldsQuerySet(models.QuerySet):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Avoid import issues
+        from . import django_patches
+
+        # Replace with our ModelIterable to be able to pass the flag
+        # when initiating models
+        self._iterable_class = django_patches.ModelIterable
+
+        # Flag to know whether dirtyfields needs to be disabled or not
+        # Not disabled by default
+        self._disable_dirtyfields = False
+
+    def disable_dirtyfields(self):
+        """Returns a new queryset with dirtyfields disabled"""
+        clone = self._clone()
+        # Set to True
+        clone._disable_dirtyfields = True
+        return clone
+
+    # NOTE: Overridden to pass disable_dirtyfields to the clone
+    def _clone(self, **kwargs):
+        clone = super()._clone(**kwargs)
+
+        # Pass disable_dirtyfields to the cloned queryset
+        clone._disable_dirtyfields = self._disable_dirtyfields
+
+        return clone
 
 
 class DirtyFieldsMixin(object):
@@ -21,19 +60,51 @@ class DirtyFieldsMixin(object):
     FIELDS_TO_CHECK = None
 
     def __init__(self, *args, **kwargs):
+
+        # Get the flag to know whether to disable dirtyfields
+        self._dirtyfields_disabled = kwargs.pop('disable_dirtyfields', False)
+
+        log.debug(f'__init__ {self._dirtyfields_disabled}')
+
         super(DirtyFieldsMixin, self).__init__(*args, **kwargs)
-        post_save.connect(
-            reset_state, sender=self.__class__, weak=False,
-            dispatch_uid='{name}-DirtyFieldsMixin-sweeper'.format(
-                name=self.__class__.__name__))
-        if self.ENABLE_M2M_CHECK:
-            self._connect_m2m_relations()
-        reset_state(sender=self.__class__, instance=self)
+
+        # Init state only if not disabled
+        if not self._dirtyfields_disabled:
+            post_save.connect(
+                reset_state, sender=self.__class__, weak=False,
+                dispatch_uid='{name}-DirtyFieldsMixin-sweeper'.format(
+                    name=self.__class__.__name__))
+            if self.ENABLE_M2M_CHECK:
+                self._connect_m2m_relations()
+            reset_state(sender=self.__class__, instance=self)
+
+    # NOTE: Overridden to pass disable_dirtyfields
+    # Additions are surrounded by ### comment blocks
+    @classmethod
+    def from_db(cls, db, field_names, values, disable_dirtyfields=None):
+        if len(values) != len(cls._meta.concrete_fields):
+            values = list(values)
+            values.reverse()
+            values = [values.pop() if f.attname in field_names else DEFERRED for f in cls._meta.concrete_fields]
+
+        ###
+        # Pass disable_dirtyfields to the model
+        log.debug(f'from_db {disable_dirtyfields} - {cls}')
+        new = cls(*values, disable_dirtyfields=disable_dirtyfields)
+        ###
+
+        new._state.adding = False
+        new._state.db = db
+        return new
 
     def refresh_from_db(self, *a, **kw):
         super(DirtyFieldsMixin, self).refresh_from_db(*a, **kw)
-        reset_state(sender=self.__class__, instance=self)
 
+        # Reset state only if not disabled
+        if not self._dirtyfields_disabled:
+            reset_state(sender=self.__class__, instance=self)
+
+    @require_non_disabled
     def _connect_m2m_relations(self):
         for m2m_field, model in get_m2m_with_model(self.__class__):
             m2m_changed.connect(
@@ -41,6 +112,7 @@ class DirtyFieldsMixin(object):
                 dispatch_uid='{name}-DirtyFieldsMixin-sweeper-m2m'.format(
                     name=self.__class__.__name__))
 
+    @require_non_disabled
     def _as_dict(self, check_relationship, include_primary_key=True):
         all_field = {}
 
@@ -77,12 +149,16 @@ class DirtyFieldsMixin(object):
                 # psycopg2 returns uncopyable type buffer for bytea
                 field_value = bytes(field_value)
 
+            # Use the column name (instead of the relationship name) if it's a
+            # foreign key.
+            key = field.attname if hasattr(field, 'attname') else field.name
             # Explanation of copy usage here :
             # https://github.com/romgar/django-dirtyfields/commit/efd0286db8b874b5d6bd06c9e903b1a0c9cc6b00
-            all_field[field.name] = deepcopy(field_value)
+            all_field[key] = deepcopy(field_value)
 
         return all_field
 
+    @require_non_disabled
     def _as_dict_m2m(self):
         m2m_fields = {}
 
@@ -95,6 +171,7 @@ class DirtyFieldsMixin(object):
 
         return m2m_fields
 
+    @require_non_disabled
     def get_dirty_fields(self, check_relationship=False, check_m2m=None, verbose=False):
         if self._state.adding:
             # If the object has not yet been saved in the database, all fields are considered dirty
@@ -127,16 +204,19 @@ class DirtyFieldsMixin(object):
 
         return modified_fields
 
+    @require_non_disabled
     def is_dirty(self, check_relationship=False, check_m2m=None):
         return {} != self.get_dirty_fields(check_relationship=check_relationship,
                                            check_m2m=check_m2m)
 
+    @require_non_disabled
     def save_dirty_fields(self):
         dirty_fields = self.get_dirty_fields(check_relationship=True)
         self.save(update_fields=dirty_fields.keys())
 
 
 def reset_state(sender, instance, **kwargs):
+    log.debug(f'RESET STATE: {sender} {instance}')
     # original state should hold all possible dirty fields to avoid
     # getting a `KeyError` when checking if a field is dirty or not
     update_fields = kwargs.pop('update_fields', {})
@@ -151,7 +231,10 @@ def reset_state(sender, instance, **kwargs):
                 if field.get_attname() in instance.get_deferred_fields():
                     continue
 
-                instance._original_state[field.name] = new_state[field.name]
+                # Use the column name (instead of the relationship name) if it's a
+                # foreign key.
+                key = field.attname if hasattr(field, 'attname') else field.name
+                instance._original_state[key] = new_state[key]
 
     else:
         instance._original_state = new_state

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -64,7 +64,7 @@ class DirtyFieldsMixin(object):
         # Get the flag to know whether to disable dirtyfields
         self._dirtyfields_disabled = kwargs.pop('disable_dirtyfields', False)
 
-        log.debug(f'__init__ {self._dirtyfields_disabled}')
+        log.debug(f'__init__ {self._dirtyfields_disabled} id(instance)={id(self)}')
 
         super(DirtyFieldsMixin, self).__init__(*args, **kwargs)
 
@@ -216,7 +216,7 @@ class DirtyFieldsMixin(object):
 
 
 def reset_state(sender, instance, **kwargs):
-    log.debug(f'RESET STATE: {sender} {instance}')
+    log.debug(f'RESET STATE: {sender} id(instance)={id(instance)}')
     # original state should hold all possible dirty fields to avoid
     # getting a `KeyError` when checking if a field is dirty or not
     update_fields = kwargs.pop('update_fields', {})

--- a/src/dirtyfields/django_patches.py
+++ b/src/dirtyfields/django_patches.py
@@ -1,0 +1,138 @@
+"""
+Override some of the core classes of django
+
+"""
+import logging
+import django.db.models.query
+from .dirtyfields import DirtyFieldsMixin
+
+
+log = logging.getLogger(__name__)
+
+
+# NOTE: Overridden to pass the flag to disable dirtyfields for the related objects
+# Additions are surrounded by ### comment blocks
+class RelatedPopulator(django.db.models.query.RelatedPopulator):
+
+    def populate(self, row, from_obj):
+
+        ###
+        # Get the flag from the object
+        dirtyfields_disabled = from_obj._dirtyfields_disabled
+        ###
+
+        if self.reorder_for_init:
+            obj_data = self.reorder_for_init(row)
+        else:
+            obj_data = row[self.cols_start:self.cols_end]
+        if obj_data[self.pk_idx] is None:
+            obj = None
+        else:
+            ###
+            # Pass disable_dirtyfield only if it's a subclass of DirtyFieldsMixin
+            # because only a subclass of DirtyFieldsMixin will support this kwarg
+            if issubclass(self.model_cls, DirtyFieldsMixin):
+                obj = self.model_cls.from_db(
+                    self.db, self.init_list, obj_data,
+                    # Pass disable_dirtyfields
+                    disable_dirtyfields=dirtyfields_disabled
+                )
+            else:
+                if dirtyfields_disabled:
+                    log.warning(
+                        f'Dirtyfields is disabled but this model does not '
+                        f'support it: {self.model_cls} '
+                        f'=> Inherit from DirtyFieldsMixin to support it'
+                    )
+                obj = self.model_cls.from_db(self.db, self.init_list, obj_data)
+            ###
+
+        if obj and self.related_populators:
+            for rel_iter in self.related_populators:
+                rel_iter.populate(row, obj)
+        setattr(from_obj, self.cache_name, obj)
+        if obj and self.reverse_cache_name:
+            setattr(obj, self.reverse_cache_name, from_obj)
+
+
+# NOTE: Overridden to use our RelatedPopulator
+def get_related_populators(klass_info, select, db):
+    iterators = []
+    related_klass_infos = klass_info.get('related_klass_infos', [])
+    for rel_klass_info in related_klass_infos:
+        ###
+        # Use our RelatedPopulator
+        rel_cls = RelatedPopulator(rel_klass_info, select, db)
+        ###
+        iterators.append(rel_cls)
+    return iterators
+
+
+# NOTE: Overridden to pass the flag to disable dirtyfields from the queryset to the model creation
+# Additions are surrounded by ### comment blocks
+class ModelIterable(django.db.models.query.ModelIterable):
+
+    def __iter__(self):
+        queryset = self.queryset
+
+        ###
+        # Get disable_dirtyfields from the queryset
+        disable_dirtyfields = queryset._disable_dirtyfields
+        ###
+
+        db = queryset.db
+        compiler = queryset.query.get_compiler(using=db)
+        # Execute the query. This will also fill compiler.select, klass_info,
+        # and annotations.
+        results = compiler.execute_sql(chunked_fetch=self.chunked_fetch)
+        select, klass_info, annotation_col_map = (compiler.select, compiler.klass_info,
+                                                  compiler.annotation_col_map)
+        model_cls = klass_info['model']
+        select_fields = klass_info['select_fields']
+        model_fields_start, model_fields_end = select_fields[0], select_fields[-1] + 1
+        init_list = [f[0].target.attname
+                     for f in select[model_fields_start:model_fields_end]]
+        related_populators = get_related_populators(klass_info, select, db)
+        for row in compiler.results_iter(results):
+
+            ###
+            # Pass disable_dirtyfield only if it's a subclass of DirtyFieldsMixin
+            # because only a subclass of DirtyFieldsMixin will support this kwarg
+            if issubclass(model_cls, DirtyFieldsMixin):
+                obj = model_cls.from_db(
+                    db, init_list, row[model_fields_start:model_fields_end],
+                    # Pass disable_dirtyfields
+                    disable_dirtyfields=disable_dirtyfields
+                )
+            else:
+                if disable_dirtyfields:
+                    log.warning(
+                        f'Dirtyfields is disabled but this model does not '
+                        f'support it: {model_cls} '
+                        f'=> Inherit from DirtyFieldsMixin to support it'
+                    )
+                obj = model_cls.from_db(db, init_list, row[model_fields_start:model_fields_end])
+            ###
+
+            if related_populators:
+                for rel_populator in related_populators:
+                    rel_populator.populate(row, obj)
+            if annotation_col_map:
+                for attr_name, col_pos in annotation_col_map.items():
+                    setattr(obj, attr_name, row[col_pos])
+
+            # Add the known related objects to the model, if there are any
+            if queryset._known_related_objects:
+                for field, rel_objs in queryset._known_related_objects.items():
+                    # Avoid overwriting objects loaded e.g. by select_related
+                    if hasattr(obj, field.get_cache_name()):
+                        continue
+                    pk = getattr(obj, field.get_attname())
+                    try:
+                        rel_obj = rel_objs[pk]
+                    except KeyError:
+                        pass  # may happen in qs1 | qs2 scenarios
+                    else:
+                        setattr(obj, field.name, rel_obj)
+
+            yield obj

--- a/src/dirtyfields/exceptions.py
+++ b/src/dirtyfields/exceptions.py
@@ -1,0 +1,6 @@
+class DirtyFieldsException(Exception):
+    pass
+
+
+class DirtyFieldsDisabled(DirtyFieldsException):
+    pass


### PR DESCRIPTION
Related to: https://github.com/romgar/django-dirtyfields/issues/132
I would love your insights on this and maybe a better solution?

Notes:
- works on Python 3.6.0 and `Django==1.11.5`
- does NOT currently support `prefetch_related` but supports `select_related`.

