### PR TITLE
Make FIELDS_TO_CHECK uses casual field name in case of ForeignKey

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -42,7 +42,7 @@ class DirtyFieldsMixin(object):
         deferred_fields = self.get_deferred_fields()
 
         for field in self._meta.fields:
-            if self.FIELDS_TO_CHECK and (field.get_attname() not in self.FIELDS_TO_CHECK):
+            if self.FIELDS_TO_CHECK and (field.name not in self.FIELDS_TO_CHECK):
                 continue
 
             if field.primary_key and not include_primary_key:
@@ -138,8 +138,7 @@ def reset_state(sender, instance, **kwargs):
     if update_fields:
         for field_name in update_fields:
             field = sender._meta.get_field(field_name)
-            if not FIELDS_TO_CHECK or \
-                    (field.get_attname() in FIELDS_TO_CHECK):
+            if not FIELDS_TO_CHECK or (field.name in FIELDS_TO_CHECK):
 
                 if field.get_attname() in instance.get_deferred_fields():
                     continue

--- a/tests/models.py
+++ b/tests/models.py
@@ -129,7 +129,7 @@ class TestModelWithSpecifiedFieldsAndForeignKey(DirtyFieldsMixin, models.Model):
     boolean1 = models.BooleanField(default=True)
     boolean2 = models.BooleanField(default=True)
     fk_field = models.OneToOneField(TestModel, null=True)
-    FIELDS_TO_CHECK = ['fk_field_id']
+    FIELDS_TO_CHECK = ['fk_field']
 
 
 class TestModelWithM2MAndSpecifiedFields(DirtyFieldsMixin, models.Model):


### PR DESCRIPTION
It's really confusing when specifying FIELDS_TO_CHECK to put your FK field name _id inside of it.