### PR TITLE
Update Python & Django support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,30 @@
+dist: xenial
+
 language: python
 
 matrix:
   include:
     # Python version is just for the look on travis.
     - python: 2.7
-      env: TOXENV=py27-django18
-    - python: 2.7
-      env: TOXENV=py27-django19
-    - python: 2.7
-      env: TOXENV=py27-django110
-    - python: 2.7
       env: TOXENV=py27-django111
-    - python: 3.4
-      env: TOXENV=py34-django18
-    - python: 3.4
-      env: TOXENV=py34-django19
-    - python: 3.4
-      env: TOXENV=py34-django110
-    - python: 3.4
-      env: TOXENV=py34-django111
-    - python: 3.5
-      env: TOXENV=py35-django18
-    - python: 3.5
-      env: TOXENV=py35-django19
-    - python: 3.5
-      env: TOXENV=py35-django110
     - python: 3.5
       env: TOXENV=py35-django111
     - python: 3.6
       env: TOXENV=py36-django111
+    - python: 3.7
+      env: TOXENV=py37-django111
+    - python: 3.5
+      env: TOXENV=py35-django20
     - python: 3.6
       env: TOXENV=py36-django20
+    - python: 3.7
+      env: TOXENV=py37-django20
+    - python: 3.5
+      env: TOXENV=py35-django21
+    - python: 3.6
+      env: TOXENV=py36-django21
+    - python: 3.7
+      env: TOXENV=py37-django21
     - python: 2.7
       env: TOXENV=py27-flake8
     - python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
   - pip install -e .
 
 after_success:
-  - if test "$TOXENV" = "coverage"; then coveralls; fi
+  - if test "$TOXENV" = "py36-django111-coverage"; then coveralls; fi
 
 deploy:
   provider: pypi

--- a/CLASSIFIERS.txt
+++ b/CLASSIFIERS.txt
@@ -6,8 +6,11 @@ Programming Language :: Python
 Programming Language :: Python :: 2
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
+Programming Language :: Python :: 3.7
 Framework :: Django
+Framework :: Django :: 1.11
+Framework :: Django :: 2.0
+Framework :: Django :: 2.1
 Topic :: Software Development :: Libraries :: Python Modules

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -7,7 +7,13 @@ master (unreleased)
 -------------------
 
 *New:*
-    - Test against the whole Python-Django matrix with Tox & Travis
+    - Drop support of Python 3.4
+    - Confirm support of Python 3.7
+    - Drop support of Django 1.8
+    - Drop support of Django 1.9
+    - Drop support of Django 1.10
+    - Confirm support of Django 2.0
+    - Confirm support of Django 2.1
 
 *Bugfix:*
     - Fix tests for Django 2.0

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,18 @@ Django Dirty Fields
 Tracking dirty fields on a Django model instance.
 Dirty means that field in-memory and database values are different.
 
-This package is compatible and tested with latest versions of Django (1.8, 1.9, 1.10, 1.11 series).
+This package is compatible and tested with the following Python & Django versions:
+
+
+
++----------+---------------------------------------+
+| Django   | Python                                |
++==========+=======================================+
+| 1.11     | 2.7, 3.5, 3.6, 3.7 (added in 1.11.17) |
++----------+---------------------------------------+
+| 2.0, 2.1 | 3.5, 3.6, 3.7                         |
++----------+---------------------------------------+
+
 
 `Full documentation <http://django-dirtyfields.readthedocs.org/en/develop/>`_
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django>=1.8
+Django>=1.11
 pytz>=2015.7

--- a/src/dirtyfields/compat.py
+++ b/src/dirtyfields/compat.py
@@ -1,16 +1,4 @@
 import sys
-import django
-
-
-def get_m2m_with_model(given_model):
-    if django.VERSION < (1, 9):
-        return given_model._meta.get_m2m_with_model()
-    else:
-        return [
-            (f, f.model if f.model != given_model else None)
-            for f in given_model._meta.get_fields()
-            if f.many_to_many and not f.auto_created
-        ]
 
 
 def is_buffer(value):
@@ -18,10 +6,3 @@ def is_buffer(value):
         return isinstance(value, buffer)  # noqa
     else:
         return isinstance(value, memoryview)
-
-
-def remote_field(field):
-    if django.VERSION < (1, 9):
-        return field.rel
-    else:
-        return field.remote_field

--- a/tests-requirements.txt
+++ b/tests-requirements.txt
@@ -1,3 +1,4 @@
 pytest==3.0.6
 pytest-django==3.1.2
+jsonfield==2.0.2
 pytz

--- a/tests-requirements.txt
+++ b/tests-requirements.txt
@@ -1,4 +1,3 @@
 pytest==3.0.6
 pytest-django==3.1.2
-jsonfield==1.0.3
 pytz

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -1,8 +1,0 @@
-
-def get_model_name(klass):
-    if hasattr(klass._meta, 'model_name'):
-        model_name = klass._meta.model_name
-    else:  # Django < 1.6
-        model_name = klass._meta.module_name
-
-    return model_name

--- a/tests/test_postgresql_specific.py
+++ b/tests/test_postgresql_specific.py
@@ -4,7 +4,7 @@ from tests.utils import is_postgresql_env_with_json_field
 
 
 @pytest.mark.skipif(not is_postgresql_env_with_json_field(),
-                    reason="requires postgresql and Django 1.9+")
+                    reason="requires postgresql >= 9.0.4")
 @pytest.mark.django_db
 def test_dirty_json_field():
     from tests.models import TestModelWithJSONField

--- a/tests/test_save_fields.py
+++ b/tests/test_save_fields.py
@@ -1,4 +1,3 @@
-import django
 import pytest
 
 from .models import TestModel, TestMixedFieldsModel, TestModelWithForeignKey
@@ -122,7 +121,4 @@ def test_save_deferred_field_with_update_fields_behaviour():
     tm = TestModel.objects.defer('boolean').first()
     tm.save(update_fields=['boolean'])
     tm.boolean = False
-    if django.VERSION < (1, 10):
-        assert tm.get_dirty_fields() == {}
-    else:
-        assert tm.get_dirty_fields() == {'boolean': True}
+    assert tm.get_dirty_fields() == {'boolean': True}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,8 +3,6 @@ import re
 from django.conf import settings
 from django.db import connection
 
-from .compat import get_model_name
-
 
 class assert_number_queries(object):
 
@@ -51,7 +49,7 @@ class assert_number_of_queries_on_regex(RegexMixin, assert_number_queries):
 class assert_select_number_queries_on_model(assert_number_of_queries_on_regex):
 
     def __init__(self, model_class, number):
-        model_name = get_model_name(model_class)
+        model_name = model_class._meta.model_name
         regex = r'^.*SELECT.*FROM "tests_%s".*$' % model_name
 
         super(assert_select_number_queries_on_model, self).__init__(regex, number)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,5 @@
 import re
 
-import django
-
 from django.conf import settings
 from django.db import connection
 
@@ -65,4 +63,4 @@ def is_postgresql_env_with_json_field():
     except AttributeError:
         PG_VERSION = 0
 
-    return PG_VERSION >= 90400 and django.VERSION >= (1, 9)
+    return PG_VERSION >= 90400

--- a/tox.ini
+++ b/tox.ini
@@ -59,5 +59,5 @@ deps =
 commands =
     python --version
     pip freeze -l
-    coverage run --branch --source dirtyfields --source tests -m py.test --ds=tests.django_settings
+    coverage run --branch --source dirtyfields,tests -m py.test --ds=tests.django_settings
     coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -59,5 +59,5 @@ deps =
 commands =
     python --version
     pip freeze -l
-    coverage run --branch --source dirtyfields -m py.test --ds=tests.django_settings
+    coverage run --branch --source dirtyfields --source tests -m py.test --ds=tests.django_settings
     coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 skipsdist = True
 envlist =
-    py{27,34,35}-django{18,19,110,111}
-    py36-django{111,20}
+    py{27,35,36,37}-django111
+    py{35,36,37}-django20
+    py{35,36,37}-django21
     py{27,36}-flake8
     py36-django111-coverage
     py36-django111-postgresql
@@ -14,11 +15,9 @@ setenv =
     PYTHONPATH = {toxinidir}
 deps =
     -rtests-requirements.txt
-    django18: Django>=1.8,<1.8.99
-    django19: Django>=1.9,<1.9.99
-    django110: Django>=1.10,<1.10.99
     django111: Django>=1.11,<1.11.99
     django20: Django>=2.0,<2.0.99
+    django21: Django>=2.1,<2.1.99
 commands =
     python --version
     pip freeze -l


### PR DESCRIPTION
https://docs.djangoproject.com/en/2.1/faq/install/#what-python-version-can-i-use-with-django

- Drop support of Python 3.4
- Confirm support of Python 3.7
- Drop support of Django 1.8
- Drop support of Django 1.9
- Drop support of Django 1.10
- Confirm support of Django 2.0
- Confirm support of Django 2.1
