### PR TITLE
Fix F632: replacing is by ==

### DIFF
--- a/tests/test_non_regression.py
+++ b/tests/test_non_regression.py
@@ -123,18 +123,18 @@ def test_pre_save_signal_make_dirty_checking_not_consistent():
 
     # first case
     model = TestModelWithPreSaveSignal.objects.create(data='specific_value')
-    assert model.data_updated_on_presave is 'presave_value'
+    assert model.data_updated_on_presave == 'presave_value'
 
     # second case
     model = TestModelWithPreSaveSignal(data='specific_value')
     model.save()
-    assert model.data_updated_on_presave is 'presave_value'
+    assert model.data_updated_on_presave == 'presave_value'
 
     # third case
     model = TestModelWithPreSaveSignal()
     model.data = 'specific_value'
     model.save()
-    assert model.data_updated_on_presave is 'presave_value'
+    assert model.data_updated_on_presave == 'presave_value'
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fixes:
```
py36-flake8 runtests: commands[1] | flake8 src tests
tests/test_non_regression.py:126:12: F632 use ==/!= to compare str, bytes, and int literals
```