### PR TITLE
Option to automatically include DateTimeFields with auto_now enabled

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -151,14 +151,12 @@ class DirtyFieldsMixin(object):
                 except ValidationError:
                     # The current value is not valid so we cannot convert it
                     pass
-                print(field.name, field_value)
                 current_value = None
                 if isinstance(field, DateTimeField):
                     current_value = timezone.now()
                 elif isinstance(field, DateField):
                     current_value = datetime.date.today()
                 auto_add_fields[field.name] = {"saved": field_value, "current": current_value}
-            print(auto_add_fields)
             modified_fields.update(auto_add_fields)
 
         if not verbose:

--- a/tests/models.py
+++ b/tests/models.py
@@ -68,6 +68,12 @@ class TestCurrentDatetimeModel(DirtyFieldsMixin, models.Model):
     datetime_field = models.DateTimeField(default=timezone.now)
 
 
+class TestAutoNowDatetimeModel(DirtyFieldsMixin, models.Model):
+    datetime_field = models.DateTimeField(auto_now=True)
+    date_field = models.DateField(auto_now=True)
+    test_string = models.TextField()
+
+
 class TestM2MModel(DirtyFieldsMixin, models.Model):
     m2m_field = models.ManyToManyField(TestModel)
     ENABLE_M2M_CHECK = True

--- a/tests/test_auto_now.py
+++ b/tests/test_auto_now.py
@@ -1,0 +1,29 @@
+from decimal import Decimal
+import pytest
+
+from .models import TestAutoNowDatetimeModel
+
+
+@pytest.mark.django_db
+def test_auto_now_updated_on_save_dirty_fields():
+    tm = TestAutoNowDatetimeModel.objects.create(test_string="test")
+
+    previous_datetime = tm.datetime_field
+    previous_date = tm.date_field
+
+    # If the object has just been saved in the db, fields are not dirty
+    assert not tm.is_dirty()
+
+    # As soon as we change a field, it becomes dirty
+    tm.test_string = "changed"
+    assert tm.is_dirty()
+
+    assert tm.get_dirty_fields(include_auto_now=True) == {
+        "test_string": "test",
+        "datetime_field": previous_datetime,
+        "date_field": previous_date,
+    }
+    tm.save_dirty_fields(include_auto_now=True)
+    tm.refresh_from_db()
+    assert tm.datetime_field > previous_datetime
+    assert tm.date_field == previous_date  # date most likely will not change during updates


### PR DESCRIPTION
Add an option to automatically include `DateTimeField` and `DateField` with `auto_now` set to `True` to a list of dirty fields in case any other field has changed.