### PR TITLE
Fix issue where refresh_from_db(fields=fields) resets the entire dirty state

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -6,7 +6,11 @@ ChangeLog
 master
 ------
 
-Up-to-date with 1.4 release.
+*Bugfix:*
+    - Fixes an issue when :code:`refresh_from_db` was called with the :code:`fields` argument, the dirty state for all
+      fields would be reset, even though only the fields specified are reloaded from the database. Now only the reloaded
+      fields will have their dirty state reset (#154).
+    - Fixes an issue where accessing a deferred field would reset the dirty state for all fields (#154).
 
 .. _v1.4:
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -173,3 +173,16 @@ def test_refresh_from_db():
 
     tm.refresh_from_db()
     assert tm.get_dirty_fields() == {}
+
+
+@pytest.mark.django_db
+def test_refresh_from_db_particular_fields():
+    tm = TestModel.objects.create(characters="old value")
+    tm.boolean = False
+    tm.characters = "new value"
+    assert tm.get_dirty_fields() == {"boolean": True, "characters": "old value"}
+
+    tm.refresh_from_db(fields={"characters"})
+    assert tm.boolean is False
+    assert tm.characters == "old value"
+    assert tm.get_dirty_fields() == {"boolean": True}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -186,3 +186,16 @@ def test_refresh_from_db_particular_fields():
     assert tm.boolean is False
     assert tm.characters == "old value"
     assert tm.get_dirty_fields() == {"boolean": True}
+
+
+@pytest.mark.django_db
+def test_refresh_from_db_no_fields():
+    tm = TestModel.objects.create(characters="old value")
+    tm.boolean = False
+    tm.characters = "new value"
+    assert tm.get_dirty_fields() == {"boolean": True, "characters": "old value"}
+
+    tm.refresh_from_db(fields=set())
+    assert tm.boolean is False
+    assert tm.characters == "new value"
+    assert tm.get_dirty_fields() == {"boolean": True, "characters": "old value"}

--- a/tests/test_save_fields.py
+++ b/tests/test_save_fields.py
@@ -66,6 +66,23 @@ def test_save_only_specific_fields_should_let_other_fields_dirty():
 
 
 @pytest.mark.django_db
+def test_save_empty_update_fields_wont_reset_dirty_state():
+    tm = TestModel.objects.create(boolean=True, characters='dummy')
+
+    tm.boolean = False
+    tm.characters = 'new_dummy'
+    assert tm.get_dirty_fields() == {"boolean": True, 'characters': 'dummy'}
+
+    # Django docs say "An empty update_fields iterable will skip the save",
+    # so this should not change the dirty state.
+    tm.save(update_fields=[])
+
+    assert tm.boolean is False
+    assert tm.characters == "new_dummy"
+    assert tm.get_dirty_fields() == {"boolean": True, 'characters': 'dummy'}
+
+
+@pytest.mark.django_db
 def test_handle_foreignkeys_id_field_in_update_fields():
     tm1 = TestModel.objects.create(boolean=True, characters='dummy')
     tm2 = TestModel.objects.create(boolean=True, characters='dummy')


### PR DESCRIPTION
Add tests that demonstrate bug in refresh_from_db()