### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,53 @@ matrix:
       env: TOXENV=py36-django111-coverage
     - python: 3.6
       env: TOXENV=py36-django111-postgresql
+      # Adding jobs for ppc64le architecture
+    - python: 3.5
+      env: TOXENV=py35-django111
+      arch: ppc64le
+    - python: 3.6
+      env: TOXENV=py36-django111
+      arch: ppc64le
+    - python: 3.7
+      env: TOXENV=py37-django111
+      arch: ppc64le
+    - python: 3.5
+      env: TOXENV=py35-django20
+      arch: ppc64le
+    - python: 3.6
+      env: TOXENV=py36-django20
+      arch: ppc64le
+    - python: 3.7
+      env: TOXENV=py37-django20
+      arch: ppc64le
+    - python: 3.5
+      env: TOXENV=py35-django21
+      arch: ppc64le
+    - python: 3.6
+      env: TOXENV=py36-django21
+      arch: ppc64le
+    - python: 3.7
+      env: TOXENV=py37-django21
+      arch: ppc64le
+    - python: 3.5
+      env: TOXENV=py35-django22
+      arch: ppc64le
+    - python: 3.6
+      env: TOXENV=py36-django22
+      arch: ppc64le
+    - python: 3.7
+      env: TOXENV=py37-django22
+      arch: ppc64le
+    - python: 3.6
+      env: TOXENV=py36-flake8
+      arch: ppc64le
+    - python: 3.6
+      env: TOXENV=py36-django111-coverage
+      arch: ppc64le
+    - python: 3.6
+      env: TOXENV=py36-django111-postgresql
+      arch: ppc64le
+
 
 services:
   - postgresql
@@ -46,7 +93,6 @@ addons:
 
 before_script:
   - psql -c 'create database dirtyfields_test;' -U postgres
-
 script:
   - tox
 


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the PR and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://www.travis-ci.com/github/kishorkunal-raj/django-dirtyfields/builds/207217078

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj