### PR TITLE
Drop is_buffer

### DIFF
--- a/src/dirtyfields/compat.py
+++ b/src/dirtyfields/compat.py
@@ -1,8 +1,0 @@
-import sys
-
-
-def is_buffer(value):
-    if sys.version_info < (3, 0, 0):
-        return isinstance(value, buffer)  # noqa
-    else:
-        return isinstance(value, memoryview)

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -7,7 +7,6 @@ from django.db.models.expressions import Combinable
 from django.db.models.signals import post_save, m2m_changed
 
 from .compare import raw_compare, compare_states, normalise_value
-from .compat import is_buffer
 
 
 def get_m2m_with_model(given_model):
@@ -86,7 +85,7 @@ class DirtyFieldsMixin(object):
                 # The current value is not valid so we cannot convert it
                 pass
 
-            if is_buffer(field_value):
+            if isinstance(field_value, memoryview):
                 # psycopg2 returns uncopyable type buffer for bytea
                 field_value = bytes(field_value)
 


### PR DESCRIPTION
This only runs on Python < 3.  The README only claims compatibility with
Python 3.5 at the oldest.

Note: This is untested.