### PR TITLE
Use concrete_fields to capture instance state

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -58,7 +58,7 @@ class DirtyFieldsMixin(object):
 
         deferred_fields = self.get_deferred_fields()
 
-        for field in self._meta.fields:
+        for field in self._meta.concrete_fields:
 
             # For backward compatibility reasons, in particular for fkey fields, we check both
             # the real name and the wrapped name (it means that we can specify either the field


### PR DESCRIPTION
This trims the set of fields dirtyfields needs to look at to generate its instance state. Concrete fields are explicitly those that correspond to a database column, which is consistent with goal of `_as_dict` as stated in its docstring.

I'm opening this because I have a custom virtual field that doesn't create a database column, which shows up in `fields` but not `concrete_fields`. Accessing the field involves a database query, so that's happening every time a model using this field and dirtyfields is instantiated.