### PR TITLE
Fix FileField performance regression caused by Django 3.1

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -6,6 +6,9 @@ ChangeLog
 master
 ------
 
+*Changed:*
+    - Only look at the file name when determining File based dirty fields.
+
 *Documentation:*
     - Document limitations when using dirtyfields and database transactions (#148).
 

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 
 from django.core.exceptions import ValidationError
+from django.core.files import File
 from django.db.models.expressions import BaseExpression
 from django.db.models.expressions import Combinable
 from django.db.models.signals import post_save, m2m_changed
@@ -78,6 +79,11 @@ class DirtyFieldsMixin(object):
                 continue
 
             field_value = getattr(self, field.attname)
+
+            if isinstance(field_value, File):
+                # Uses the path for files due to a perfomance regression caused by Django 3.1.
+                # For more info see: https://github.com/romgar/django-dirtyfields/issues/165
+                field_value = field_value.path if field_value else ''
 
             # If current field value is an expression, we are not evaluating it
             if isinstance(field_value, (BaseExpression, Combinable)):

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -81,9 +81,9 @@ class DirtyFieldsMixin(object):
             field_value = getattr(self, field.attname)
 
             if isinstance(field_value, File):
-                # Uses the path for files due to a perfomance regression caused by Django 3.1.
+                # Uses the name for files due to a perfomance regression caused by Django 3.1.
                 # For more info see: https://github.com/romgar/django-dirtyfields/issues/165
-                field_value = field_value.path if field_value else ''
+                field_value = field_value.name
 
             # If current field value is an expression, we are not evaluating it
             if isinstance(field_value, (BaseExpression, Combinable)):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -231,7 +231,7 @@ def test_file_fields_content_file():
 
     # change file makes field dirty
     tm.file1.save("test-file-2.txt", ContentFile(b"Test file content 2"), save=False)
-    assert tm.get_dirty_fields() == {"file1": f"{settings.MEDIA_ROOT}/file1/test-file-1.txt"}
+    assert tm.get_dirty_fields() == {"file1": "file1/test-file-1.txt"}
     tm.save()
     assert tm.get_dirty_fields() == {}
 
@@ -254,7 +254,7 @@ def test_file_fields_real_file():
     # change file makes field dirty
     with open(join(dirname(__file__), "files", "bar.txt"), "rb") as f:
         tm.file1.save("test-file-4.txt", File(f), save=False)
-    assert tm.get_dirty_fields() == {"file1": f"{settings.MEDIA_ROOT}/file1/test-file-3.txt"}
+    assert tm.get_dirty_fields() == {"file1": "file1/test-file-3.txt"}
     tm.save()
     assert tm.get_dirty_fields() == {}
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 from os.path import dirname, join
 
 import pytest
+from django.conf import settings
 from django.core.files.base import ContentFile, File
 from django.db import DatabaseError, transaction
 
@@ -10,7 +11,6 @@ from .models import (ModelTest, ModelWithForeignKeyTest,
                      ModelWithOneToOneFieldTest,
                      SubclassModelTest, ModelWithDecimalFieldTest,
                      FileFieldModel)
-from .utils import FakeFieldFile
 
 
 def test_version_numbers():
@@ -219,19 +219,19 @@ def test_refresh_from_db_no_fields():
 def test_file_fields_content_file():
     tm = FileFieldModel()
     # field is dirty because model is unsaved
-    assert tm.get_dirty_fields() == {"file1": FakeFieldFile("")}
+    assert tm.get_dirty_fields() == {"file1": ""}
     tm.save()
     assert tm.get_dirty_fields() == {}
 
     # set file makes field dirty
     tm.file1.save("test-file-1.txt", ContentFile(b"Test file content 1"), save=False)
-    assert tm.get_dirty_fields() == {"file1": FakeFieldFile("")}
+    assert tm.get_dirty_fields() == {"file1": ""}
     tm.save()
     assert tm.get_dirty_fields() == {}
 
     # change file makes field dirty
     tm.file1.save("test-file-2.txt", ContentFile(b"Test file content 2"), save=False)
-    assert tm.get_dirty_fields() == {"file1": FakeFieldFile("file1/test-file-1.txt")}
+    assert tm.get_dirty_fields() == {"file1": f"{settings.MEDIA_ROOT}/file1/test-file-1.txt"}
     tm.save()
     assert tm.get_dirty_fields() == {}
 
@@ -240,21 +240,21 @@ def test_file_fields_content_file():
 def test_file_fields_real_file():
     tm = FileFieldModel()
     # field is dirty because model is unsaved
-    assert tm.get_dirty_fields() == {"file1": FakeFieldFile("")}
+    assert tm.get_dirty_fields() == {"file1": ""}
     tm.save()
     assert tm.get_dirty_fields() == {}
 
     # set file makes field dirty
     with open(join(dirname(__file__), "files", "foo.txt"), "rb") as f:
         tm.file1.save("test-file-3.txt", File(f), save=False)
-    assert tm.get_dirty_fields() == {"file1": FakeFieldFile("")}
+    assert tm.get_dirty_fields() == {"file1": ""}
     tm.save()
     assert tm.get_dirty_fields() == {}
 
     # change file makes field dirty
     with open(join(dirname(__file__), "files", "bar.txt"), "rb") as f:
         tm.file1.save("test-file-4.txt", File(f), save=False)
-    assert tm.get_dirty_fields() == {"file1": FakeFieldFile("file1/test-file-3.txt")}
+    assert tm.get_dirty_fields() == {"file1": f"{settings.MEDIA_ROOT}/file1/test-file-3.txt"}
     tm.save()
     assert tm.get_dirty_fields() == {}
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,4 @@
 import re
-from collections import namedtuple
 
 from django.conf import settings
 from django.db import connection
@@ -63,7 +62,3 @@ def is_postgresql_env_with_jsonb_field():
         PG_VERSION = 0
 
     return PG_VERSION >= 90400
-
-
-# Will compare equal with a django `FieldFile` instance in tests.
-FakeFieldFile = namedtuple("FakeFieldFile", ["name"])


### PR DESCRIPTION
Attempts to fix #165 by representing file fields as their filepath strings in `_as_dict `