### PR TITLE
make sure unexpected save is not called if model wasn't changed

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -46,7 +46,7 @@ use ``check_relationship`` parameter:
 Saving dirty fields.
 --------------------
 If you want to only save dirty fields from an instance in the database (only these fields will be involved in SQL query),
-you can use ``save_dirty_fields()`` method.
+you can use ``save_dirty_fields()`` method. If model wasn't changed save won't be called.
 
 Warning: This calls the ``save()`` method internally so will trigger the same signals as normally calling the ``save()`` method.
 

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -153,6 +153,8 @@ class DirtyFieldsMixin(object):
 
     def save_dirty_fields(self):
         dirty_fields = self.get_dirty_fields(check_relationship=True)
+        if not dirty_fields:
+            return
         self.save(update_fields=dirty_fields.keys())
 
 

--- a/tests/test_save_fields.py
+++ b/tests/test_save_fields.py
@@ -60,6 +60,19 @@ def test_save_dirty_related_field():
 
 
 @pytest.mark.django_db
+def test_save_dirty_dont_call_save_without_changes():
+    tm = ModelTest.objects.create()
+
+    assert tm.get_dirty_fields() == {}
+
+    # Naive checking on fields involved in Django query
+    # boolean unchanged field is not updated on Django update query: GOOD !
+    with assert_number_of_queries_on_regex(r'.*characters.*', 0):
+        with assert_number_of_queries_on_regex(r'.*boolean.*', 0):
+            tm.save_dirty_fields()
+
+
+@pytest.mark.django_db
 def test_save_only_specific_fields_should_let_other_fields_dirty():
     tm = ModelTest.objects.create(boolean=True, characters='dummy')
 


### PR DESCRIPTION
at the first look at the source code it wasn't clear to me that calling save with empty `update_fields` just returns without any action on a DB instead of saving all fields (to check that I had to look at django internals)