### PR TITLE
add full_save_on_add arg to save_dirty_fields to save new instances

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -46,7 +46,7 @@ use ``check_relationship`` parameter:
 Saving dirty fields.
 --------------------
 If you want to only save dirty fields from an instance in the database (only these fields will be involved in SQL query),
-you can use ``save_dirty_fields()`` method.
+you can use ``save_dirty_fields()`` method. If the model instance has not been persisted yet, it will be saved in full.
 
 Warning: This calls the ``save()`` method internally so will trigger the same signals as normally calling the ``save()`` method.
 

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -152,8 +152,11 @@ class DirtyFieldsMixin(object):
                                            check_m2m=check_m2m)
 
     def save_dirty_fields(self):
-        dirty_fields = self.get_dirty_fields(check_relationship=True)
-        self.save(update_fields=dirty_fields.keys())
+        if self._state.adding:
+            self.save()
+        else:
+            dirty_fields = self.get_dirty_fields(check_relationship=True)
+            self.save(update_fields=dirty_fields.keys())
 
 
 def reset_state(sender, instance, **kwargs):

--- a/tests/test_save_fields.py
+++ b/tests/test_save_fields.py
@@ -60,6 +60,14 @@ def test_save_dirty_related_field():
 
 
 @pytest.mark.django_db
+def test_save_dirty_full_save_on_adding():
+    tm = ModelTest()
+    tm.save_dirty_fields()
+    assert tm.pk
+    assert tm.get_dirty_fields() == {}
+
+
+@pytest.mark.django_db
 def test_save_only_specific_fields_should_let_other_fields_dirty():
     tm = ModelTest.objects.create(boolean=True, characters='dummy')
 


### PR DESCRIPTION
in one of our projects with have a pattern, when we have an instance of a model, but don't know was it save to the DB or not. After updating several its fields we want to use optimized save_dirty_fields method for existing models, but save the full model otherwise.

So in this PR I try to suggest a way for simplify the case by adding a new argument to the save_dirty_fields method