### PR TITLE
fix: add param `from_queryset` to `refresh_from_db`

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -37,8 +37,10 @@ class DirtyFieldsMixin(object):
             self._connect_m2m_relations()
         reset_state(sender=self.__class__, instance=self)
 
-    def refresh_from_db(self, using=None, fields=None):
-        super(DirtyFieldsMixin, self).refresh_from_db(using=using, fields=fields)
+    def refresh_from_db(self, using=None, fields=None, from_queryset=None):
+        super(DirtyFieldsMixin, self).refresh_from_db(
+            using=using, fields=fields, from_queryset=from_queryset
+        )
         reset_state(sender=self.__class__, instance=self, update_fields=fields)
 
     def _connect_m2m_relations(self):

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-
+from django import VERSION as DJANGO_VERSION
 from django.core.exceptions import ValidationError
 from django.core.files import File
 from django.db.models.expressions import BaseExpression
@@ -38,9 +38,12 @@ class DirtyFieldsMixin(object):
         reset_state(sender=self.__class__, instance=self)
 
     def refresh_from_db(self, using=None, fields=None, from_queryset=None):
-        super(DirtyFieldsMixin, self).refresh_from_db(
-            using=using, fields=fields, from_queryset=from_queryset
-        )
+        if DJANGO_VERSION >= (5, 1):
+            super(DirtyFieldsMixin, self).refresh_from_db(
+                using=using, fields=fields, from_queryset=from_queryset
+            )
+        else:
+            super(DirtyFieldsMixin, self).refresh_from_db(using=using, fields=fields)
         reset_state(sender=self.__class__, instance=self, update_fields=fields)
 
     def _connect_m2m_relations(self):

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from django import VERSION as DJANGO_VERSION
 from django.core.exceptions import ValidationError
 from django.core.files import File
 from django.db.models.expressions import BaseExpression
@@ -37,13 +36,8 @@ class DirtyFieldsMixin(object):
             self._connect_m2m_relations()
         reset_state(sender=self.__class__, instance=self)
 
-    def refresh_from_db(self, using=None, fields=None, from_queryset=None):
-        if DJANGO_VERSION >= (5, 1):
-            super(DirtyFieldsMixin, self).refresh_from_db(
-                using=using, fields=fields, from_queryset=from_queryset
-            )
-        else:
-            super(DirtyFieldsMixin, self).refresh_from_db(using=using, fields=fields)
+    def refresh_from_db(self, using=None, fields=None, *args, **kwargs):
+        super().refresh_from_db(using=using, fields=fields, *args, **kwargs)
         reset_state(sender=self.__class__, instance=self, update_fields=fields)
 
     def _connect_m2m_relations(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -216,7 +216,7 @@ def test_refresh_from_db_no_fields():
 
 @pytest.mark.django_db
 def test_refresh_from_db_with_from_queryset():
-    """Tests passthrough of `save_queryset` field in refresh_from_db
+    """Tests passthrough of `from_queryset` field in refresh_from_db
     this field was introduced in django 5.1. more details in this PR:
     https://github.com/romgar/django-dirtyfields/pull/235
     """

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -215,6 +215,23 @@ def test_refresh_from_db_no_fields():
 
 
 @pytest.mark.django_db
+def test_refresh_from_db_with_from_queryset():
+    """Tests passthrough of `save_queryset` field in refresh_from_db
+    this field was introduced in django 5.1. more details in this PR:
+    https://github.com/romgar/django-dirtyfields/pull/235
+    """
+    tm = ModelTest.objects.create(characters="old value")
+    tm.boolean = False
+    tm.characters = "new value"
+    assert tm.get_dirty_fields() == {"boolean": True, "characters": "old value"}
+
+    tm.refresh_from_db(fields={"characters"}, from_queryset=ModelTest.objects.all())
+    assert tm.boolean is False
+    assert tm.characters == "old value"
+    assert tm.get_dirty_fields() == {"boolean": True}
+
+
+@pytest.mark.django_db
 def test_file_fields_content_file():
     tm = FileFieldModel()
     # field is dirty because model is unsaved


### PR DESCRIPTION
django updated their signature for `refresh_from_db` to include this param, so the library fails on django 5.1

link to django release note:
https://docs.djangoproject.com/en/5.1/releases/5.1/

link to django source where it changed:
https://github.com/django/django/commit/f92641a636a8cb75fc9851396cef4345510a4b52